### PR TITLE
#29 add search input to NavBar

### DIFF
--- a/ketcher/Dockerfile
+++ b/ketcher/Dockerfile
@@ -1,0 +1,97 @@
+FROM epmlsop/indigo_service
+
+# Add and build Ketcher
+WORKDIR /tmp
+RUN \
+# Install Node.js
+    apt-get update \
+ && apt-get install -y curl \
+ && curl -sL http://deb.nodesource.com/setup_10.x | bash \
+ && apt-get install -y \
+    bzip2 \
+    nodejs \
+# Download sources
+ && curl -sL http://github.com/epam/ketcher/archive/2.0.0-RC.tar.gz -o /tmp/ketcher.tar.gz \
+ && curl -sL http://github.com/epam/miew/archive/v0.7.13.tar.gz -o /tmp/miew.tar.gz \
+# Build production Ketcher files
+ && tar -xf /tmp/ketcher.tar.gz \
+ && tar -xf /tmp/miew.tar.gz \
+ && cd ketcher-2.0.0-RC \
+ && npm install \
+ && npm run build -- --api-path=/v2/ --miew-path=/tmp/miew-0.7.13/dist \
+ && mv /tmp/ketcher-2.0.0-RC/dist /srv/ketcher \
+ && mv /tmp/miew-0.7.13/dist/Miew.min.* /srv/ketcher \
+# Cleanup
+ && apt-get purge -y \
+        apt-transport-https \
+        bzip2 \
+        curl \
+        gnupg \
+        lsb-release \
+        nodejs \
+ && apt-get autoremove -y \
+ && rm -rf \
+        /tmp/ketcher.tar.gz \
+        /tmp/ketcher-2.0.0-RC \
+        /tmp/miew.tar.gz \
+        /tmp/miew-0.7.13 \
+        /tmp/phantomjs \
+        /tmp/npm* \
+        /etc/apt/sources.list.d/nodesource.list \
+        /var/lib/apt/lists/*
+
+# Add Nginx
+WORKDIR /tmp
+RUN \
+# Install Nginx
+    apt-get update \
+ && apt-get install -y nginx \
+# Set Nginx to run as root
+ && sed -i s/"user www-data"/"user root"/g /etc/nginx/nginx.conf \
+# Set uWSGI to use a socket file
+ && sed -i s/"socket = :8002"/"socket = \/tmp\/uwsgi.sock"/g /etc/uwsgi.ini \
+# Add Nginx configuration
+ && echo 'upstream indigo {\n\
+    server unix:///tmp/uwsgi.sock;\n\
+}\n\
+server {\n\
+    listen 8002 default_server;\n\
+    server_name _;\n\
+
+    access_log /dev/stdout;\n\
+    charset utf-8;\n\
+    client_max_body_size 75M;\n\
+
+    add_header "Access-Control-Allow-Origin" "*" always;\n\
+    add_header "Access-Control-Allow-Methods" "POST, GET, PUT, DELETE, OPTIONS" always;\n\
+    add_header "Access-Control-Allow-Headers" "Accept, Content-Type" always;\n\
+    add_header "Access-Control-Max-Age" "86400" always;\n\
+
+    location / {\n\
+        root /srv/ketcher;\n\
+        index ketcher.html;\n\
+    }\n\
+    location /v2 {\n\
+        include uwsgi_params;\n\
+        uwsgi_pass indigo;\n\
+    }\n\
+}' > /etc/nginx/sites-enabled/default \
+# Add supervisord start
+ && echo '[program:nginx]\n\
+directory=/srv\n\
+command=/usr/sbin/nginx -g "daemon off;"\n\
+autostart=true\n\
+autorestart=true\n\
+startsecs=0\n\
+redirect_stderr=true\n\
+stdout_logfile=/dev/stdout\n\
+stdout_logfile_maxbytes=0' > /etc/supervisor/conf.d/nginx.auto.conf \
+# Cleanup
+ && rm -rf /var/lib/apt/lists/*
+
+# Patch Ketcher to import/export
+COPY ketcher.html /srv/ketcher/ketcher.html
+
+WORKDIR /srv/api
+VOLUME /tmp/indigo-service/upload
+EXPOSE 8002

--- a/ketcher/ketcher.html
+++ b/ketcher/ketcher.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Ketcher v2.0.0-RC+r</title>
+
+  <link rel="shortcut icon" type="image/x-icon" href="logo/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="logo/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="logo/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="logo/apple-touch-icon.png">
+
+  <link rel="stylesheet" href="ketcher.css">
+  <script src="raphael.min.js"></script>
+  <script src="ketcher.js"></script>
+
+  <link rel="stylesheet" href="Miew.min.css">
+  <script src="Miew.min.js"></script>
+
+  <script>
+    window.addEventListener(
+      "message",
+      function(event) {
+        switch(event.data.type) {
+          case "importMolfile":
+            ketcher.setMolecule(event.data.molfile)
+            break;
+          case "exportMolfile":
+            window.parent.postMessage({type: "returnMolfile", molfile: ketcher.getMolfile()}, "*");
+        }
+      },
+      false
+    );
+
+  </script>
+</head>
+
+<body role="applicaion"></body>
+
+</html>

--- a/marvin/Dockerfile
+++ b/marvin/Dockerfile
@@ -1,3 +1,9 @@
 FROM hub.chemaxon.com/cxn-docker-release/chemaxon/mjs-webservice
-COPY license_MJS.cxl /home/cxnapp/.chemaxon/licenses/license_MJS.cxl
+ARG lic="US Env Lic.cxl"
+ARG mjs="US Env Lic MJS.cxl"
+ARG mrk="US Env Lic Markush E.cxl"
+ARG target="/home/cxnapp/.chemaxon/licenses/"
+COPY ${lic} ${target}
+COPY ${mjs} ${target}
+COPY ${mrk} ${target}
 COPY editorws.html /app/mjs-webservice/static/editorws.html

--- a/marvin/editorws.html
+++ b/marvin/editorws.html
@@ -1,53 +1,69 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-  <title>Marvin JS</title>
-  <link type="text/css" rel="stylesheet" href="gui/css/editor.min.css" media="screen" />
-  <script src="gui/lib/promise-1.0.0.min.js"></script>
-  <script src="js/webservices.js"></script>
-  <script src="gui/gui.nocache.js"></script>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta
+      name="viewport"
+      content="user-scalable=no, width=device-width, initial-scale=1.0, maximum-scale=1.0"
+    />
+    <title>Marvin JS</title>
+    <link
+      type="text/css"
+      rel="stylesheet"
+      href="gui/css/editor.min.css"
+      media="screen"
+    />
+    <script src="gui/lib/promise-1.0.0.min.js"></script>
+    <script src="js/webservices.js"></script>
+    <script src="gui/gui.nocache.js"></script>
 
-  <script>
-    window.addEventListener(
-      "message",
-      function(event) {
-        switch(event.data.type) {
-          case "importMrvfile":
-            marvin
-              .sketcherInstance
-              .importStructure("mrv", event.data.mrvfile);
-            break;
-          case "exportMrvfile":
-            marvin
-              .sketcherInstance
-              .exportStructure("mrv")
-              .then(val => window.parent.postMessage({type: "returnMrvfile", mrvfile: val}, "*"))
+    <script>
+      window.addEventListener(
+        "message",
+        function(event) {
+          switch (event.data.type) {
+            case "importMrvfile":
+              marvin.sketcherInstance.importStructure(
+                "mrv",
+                event.data.mrvfile
+              );
+              break;
+            case "exportMrvfile":
+              marvin.sketcherInstance
+                .exportStructure("mrv")
+                .then(val =>
+                  window.parent.postMessage(
+                    { type: "returnMrvfile", mrvfile: val },
+                    "*"
+                  )
+                );
+          }
+        },
+        false
+      );
+      // called when Marvin JS loaded
+      function sketchOnLoad() {
+        if (marvin.Sketch.isSupported()) {
+          marvin.sketcherInstance = new marvin.Sketch("sketch");
+          marvin.sketcherInstance.setServices(getDefaultServices());
+          parent.postMessage("marvinLoaded", "*");
+        } else {
+          alert(
+            "Cannot initiate sketcher. Current browser may not support HTML canvas or may run in Compatibility Mode."
+          );
         }
-      },
-      false
-    );
-    // called when Marvin JS loaded
-    function sketchOnLoad() {
-      if (marvin.Sketch.isSupported()) {
-        marvin.sketcherInstance = new marvin.Sketch("sketch");
-        marvin.sketcherInstance.setServices(getDefaultServices());
-      } else {
-        alert(
-          "Cannot initiate sketcher. Current browser may not support HTML canvas or may run in Compatibility Mode."
-        );
       }
-    }
-  </script>
-</head>
-<body class="mjs-body">
-  <noscript>
-    <div>
-      <p>Your web browser must have JavaScript enabled in order for this
-      application to display correctly.</p>
-    </div>
-  </noscript>
-  <div id="sketch"></div>
-</body>
+    </script>
+  </head>
+  <body class="mjs-body">
+    <noscript>
+      <div>
+        <p>
+          Your web browser must have JavaScript enabled in order for this
+          application to display correctly.
+        </p>
+      </div>
+    </noscript>
+    <div id="sketch"></div>
+  </body>
 </html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <NavBar />
+    <Alert />
     <transition>
       <router-view :key="$route.path" />
     </transition>
@@ -9,11 +10,13 @@
 
 <script>
 import NavBar from "@/components/NavBar.vue";
+import Alert from "@/components/Alert";
 
 export default {
   name: "App",
   components: {
-    NavBar
+    NavBar,
+    Alert
   }
 };
 </script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -1,0 +1,37 @@
+<template>
+  <b-alert
+    :show="dismissCountDown"
+    dismissible
+    fade
+    :variant="color"
+    v-on:dismissed="clearState"
+    @dismiss-count-down="countDownChanged"
+  >{{ message }}</b-alert>
+</template>
+
+<script>
+import { mapState } from "vuex";
+
+export default {
+  name: "Alert",
+  methods: {
+    countDownChanged(dismissCountDown) {
+      this.dismissCountDown = dismissCountDown;
+    },
+    clearState() {
+      this.$store.commit("alert/clearState");
+    }
+  },
+  computed: {
+    dismissCountDown: {
+      get() {
+        return this.$store.state.alert.dismissCountDown;
+      },
+      set(value) {
+        this.$store.commit("alert/setCountdown", value);
+      }
+    },
+    ...mapState("alert", ["message", "color"])
+  }
+};
+</script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -6,7 +6,8 @@
     :variant="color"
     v-on:dismissed="clearState"
     @dismiss-count-down="countDownChanged"
-  >{{ message }}</b-alert>
+    >{{ message }}</b-alert
+  >
 </template>
 
 <script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -6,8 +6,8 @@
     :variant="color"
     v-on:dismissed="clearState"
     @dismiss-count-down="countDownChanged"
-    >{{ message }}</b-alert
-  >
+    data-cy="alert-box"
+  >{{ message }}</b-alert>
 </template>
 
 <script>

--- a/src/components/Alert.vue
+++ b/src/components/Alert.vue
@@ -7,7 +7,8 @@
     v-on:dismissed="clearState"
     @dismiss-count-down="countDownChanged"
     data-cy="alert-box"
-  >{{ message }}</b-alert>
+    >{{ message }}</b-alert
+  >
 </template>
 
 <script>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <Alert />
     <b-form-select id="compound-type-dropdown" v-model="type" :options="options" class="m-1 w-25" />
     <KetcherWindow v-if="type == 'definedCompound'" />
     <MarvinWindow v-if="type == 'illDefinedCompound'" />
@@ -11,14 +10,12 @@
 import { mapState } from "vuex";
 import KetcherWindow from "@/components/KetcherWindow";
 import MarvinWindow from "@/components/MarvinWindow";
-import Alert from "@/components/Alert";
 
 export default {
   name: "ChemicalEditors",
   components: {
     KetcherWindow,
-    MarvinWindow,
-    Alert
+    MarvinWindow
   },
   data() {
     return {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <Alert />
-    <b-form-select id="compound-type-dropdown" v-model="type" :options="options" class="m-5 w-25" />
+    <b-form-select
+      id="compound-type-dropdown"
+      v-model="type"
+      :options="options"
+      class="m-5 w-25"
+    />
     <KetcherWindow v-if="type == 'definedCompound'" />
     <MarvinWindow v-if="type == 'illDefinedCompound'" />
   </div>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
-    <b-form-select id="compound-type-dropdown" v-model="type" :options="options" class="m-1 w-25" />
+    <b-form-select
+      id="compound-type-dropdown"
+      v-model="type"
+      :options="options"
+      class="m-1 w-25"
+    />
     <KetcherWindow v-if="type == 'definedCompound'" />
     <MarvinWindow v-if="type == 'illDefinedCompound'" />
   </div>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,34 +1,43 @@
 <template>
   <div>
-    <b-form-select
-      id="compound-type-dropdown"
-      v-model="selected"
-      :options="options"
-      class="m-5 w-25"
-    ></b-form-select>
-    <KetcherWindow v-if="selected == 'defined'" />
-    <MarvinWindow v-if="selected == 'ill-defined'" />
+    <Alert />
+    <b-form-select id="compound-type-dropdown" v-model="type" :options="options" class="m-5 w-25" />
+    <KetcherWindow v-if="type == 'definedCompound'" />
+    <MarvinWindow v-if="type == 'illDefinedCompound'" />
   </div>
 </template>
 
 <script>
+import { mapState } from "vuex";
 import KetcherWindow from "@/components/KetcherWindow";
 import MarvinWindow from "@/components/MarvinWindow";
+import Alert from "@/components/Alert";
 
 export default {
   name: "ChemicalEditors",
   components: {
     KetcherWindow,
-    MarvinWindow
+    MarvinWindow,
+    Alert
   },
   data() {
     return {
-      selected: "defined",
       options: [
-        { value: "defined", text: "defined" },
-        { value: "ill-defined", text: "ill-defined" }
+        { value: "definedCompound", text: "defined" },
+        { value: "illDefinedCompound", text: "ill-defined" }
       ]
     };
+  },
+  computed: {
+    type: {
+      get() {
+        return this.$store.state.compound.type;
+      },
+      set(value) {
+        this.$store.commit("compound/setType", value);
+      }
+    },
+    ...mapState("compound", ["cid"])
   }
 };
 </script>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,12 +1,7 @@
 <template>
   <div>
     <Alert />
-    <b-form-select
-      id="compound-type-dropdown"
-      v-model="type"
-      :options="options"
-      class="m-5 w-25"
-    />
+    <b-form-select id="compound-type-dropdown" v-model="type" :options="options" class="m-1 w-25" />
     <KetcherWindow v-if="type == 'definedCompound'" />
     <MarvinWindow v-if="type == 'illDefinedCompound'" />
   </div>

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -8,7 +8,8 @@
       v-bind:src="ketcherURL"
       width="800"
       height="600"
-    >ketcher</iframe>
+      >ketcher</iframe
+    >
     <br />
     <b-button
       variant="secondary"

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -65,6 +65,7 @@ export default {
         },
         "*"
       );
+      this.molfile = this.$store.state.compound.molfile;
     },
     exportMolfile: function() {
       document
@@ -100,7 +101,6 @@ export default {
       iFrame.addEventListener("load", function() {
         load();
       });
-      this.molfile = this.$store.state.compound.molfile;
     }
   }
 };

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -8,9 +8,7 @@
       v-bind:src="ketcherURL"
       width="800"
       height="600"
-    >
-      ketcher
-    </iframe>
+    >ketcher</iframe>
     <br />
     <b-button
       variant="secondary"
@@ -75,12 +73,12 @@ export default {
     }
   },
   computed: {
-    filio: function() {
+    compound: function() {
       return this.$store.state.compound.molfile;
     }
   },
   watch: {
-    filio: function() {
+    compound: function() {
       this.loadMolfile();
     }
   },
@@ -97,10 +95,11 @@ export default {
       false
     );
     if (this.$store.state.compound.molfile !== "") {
-      const load = this.loadMolfile; // lexical this, goes away in setTimeout!
-      setTimeout(function() {
+      const load = this.loadMolfile;
+      var iFrame = document.getElementById("ketcher");
+      iFrame.addEventListener("load", function() {
         load();
-      }, 300); // there is a bit of lag to get the .ketcher element to load, thus, the timeout.
+      });
       this.molfile = this.$store.state.compound.molfile;
     }
   }

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -65,7 +65,7 @@ export default {
         },
         "*"
       );
-      this.molfile = this.$store.state.compound.molfile;
+      this.exportMolfile();
     },
     exportMolfile: function() {
       document
@@ -90,7 +90,7 @@ export default {
       function(event) {
         if (event.data.type == "returnMolfile") {
           self.molfile = event.data.molfile;
-          this.molfile = this.$store.state.compound.molfile;
+          this.molfile = self.$store.state.compound.molfile;
         }
       },
       false

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <br />
     <iframe
       id="ketcher"
       class="ketcher"
@@ -10,6 +11,33 @@
     >
       ketcher
     </iframe>
+    <br />
+    <b-button
+      variant="secondary"
+      v-on:click="exportMolfile"
+      style="width:800px"
+      id="ketcher-export-button"
+    >
+      <b-icon-file-arrow-down></b-icon-file-arrow-down>Export
+    </b-button>
+    <b-form-textarea
+      id="ketcher-import-textarea"
+      v-model="molfile"
+      rows="3"
+      max-rows="6"
+      placeholder="Paste molfile to import..."
+      class="mx-auto mt-5"
+      style="width:800px"
+    ></b-form-textarea>
+    <b-button
+      variant="primary"
+      v-on:click="importMolfile"
+      class="mt-2"
+      style="width:800px"
+      id="ketcher-import-button"
+    >
+      <b-icon-file-arrow-up></b-icon-file-arrow-up>Import
+    </b-button>
   </div>
 </template>
 
@@ -18,8 +46,63 @@ export default {
   name: "KetcherWindow",
   data() {
     return {
-      ketcherURL: process.env.VUE_APP_KETCHER_URL
+      ketcherURL: process.env.VUE_APP_KETCHER_URL,
+      molfile: ""
     };
+  },
+  methods: {
+    importMolfile: function() {
+      document
+        .getElementById("ketcher")
+        .contentWindow.postMessage(
+          { type: "importMolfile", molfile: this.molfile },
+          "*"
+        );
+    },
+    loadMolfile: function() {
+      document.getElementById("ketcher").contentWindow.postMessage(
+        {
+          type: "importMolfile",
+          molfile: this.$store.state.compound.molfile
+        },
+        "*"
+      );
+    },
+    exportMolfile: function() {
+      document
+        .getElementById("ketcher")
+        .contentWindow.postMessage({ type: "exportMolfile" }, "*");
+    }
+  },
+  computed: {
+    filio: function() {
+      return this.$store.state.compound.molfile;
+    }
+  },
+  watch: {
+    filio: function() {
+      this.loadMolfile();
+    }
+  },
+  mounted() {
+    let self = this;
+    window.addEventListener(
+      "message",
+      function(event) {
+        if (event.data.type == "returnMolfile") {
+          self.molfile = event.data.molfile;
+          this.molfile = this.$store.state.compound.molfile;
+        }
+      },
+      false
+    );
+    if (this.$store.state.compound.molfile !== "") {
+      const load = this.loadMolfile; // lexical this, goes away in setTimeout!
+      setTimeout(function() {
+        load();
+      }, 300); // there is a bit of lag to get the .ketcher element to load, thus, the timeout.
+      this.molfile = this.$store.state.compound.molfile;
+    }
   }
 };
 </script>

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -1,13 +1,7 @@
 <template>
   <div>
     <br />
-    <iframe
-      id="marvin"
-      class="marvin compound"
-      data-cy="marvin"
-      v-bind:src="marvinURL"
-      >marvin</iframe
-    >
+    <iframe id="marvin" class="marvin" data-cy="marvin" v-bind:src="marvinURL">marvin</iframe>
     <br />
     <b-button
       variant="secondary"
@@ -72,12 +66,12 @@ export default {
     }
   },
   computed: {
-    filio: function() {
+    compound: function() {
       return this.$store.state.compound.mrvfile;
     }
   },
   watch: {
-    filio: function() {
+    compound: function() {
       this.loadMrvfile();
     }
   },
@@ -94,10 +88,11 @@ export default {
       false
     );
     if (this.$store.state.compound.mrvfile !== "") {
-      const load = this.loadMrvfile; // lexical this, goes away in setTimeout!
-      setTimeout(function() {
+      const load = this.loadMrvfile;
+      var iFrame = document.getElementById("marvin");
+      iFrame.addEventListener("load", function() {
         load();
-      }, 300); // there is a bit of lag to get the .marvin element to load, thus, the timeout.
+      });
       this.mrvfile = this.$store.state.compound.mrvfile;
     }
   }

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -58,6 +58,7 @@ export default {
         },
         "*"
       );
+      this.mrvfile = this.$store.state.compound.mrvfile;
     },
     exportMrvfile: function() {
       document
@@ -89,11 +90,9 @@ export default {
     );
     if (this.$store.state.compound.mrvfile !== "") {
       const load = this.loadMrvfile;
-      var iFrame = document.getElementById("marvin");
-      iFrame.addEventListener("load", function() {
+      setTimeout(function(){
         load();
-      });
-      this.mrvfile = this.$store.state.compound.mrvfile;
+      }, 300)
     }
   }
 };

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -65,6 +65,16 @@ export default {
         .contentWindow.postMessage({ type: "exportMrvfile" }, "*");
     }
   },
+  computed: {
+    filio: function() {
+      return this.$store.state.compound.mrvfile;
+    }
+  },
+  watch: {
+    filio: function() {
+      this.loadMrvfile();
+    }
+  },
   mounted() {
     let self = this;
     window.addEventListener(
@@ -72,6 +82,7 @@ export default {
       function(event) {
         if (event.data.type == "returnMrvfile") {
           self.mrvfile = event.data.mrvfile;
+          this.mrvfile = this.$store.state.compound.mrvfile;
         }
       },
       false

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -33,8 +33,6 @@
 </template>
 
 <script>
-// import onElementReady from "../utils/onElementReady";
-
 export default {
   name: "MarvinWindow",
   data() {

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <br />
-    <iframe id="marvin" class="marvin" data-cy="marvin" v-bind:src="marvinURL">marvin</iframe>
+    <iframe id="marvin" class="marvin" data-cy="marvin" v-bind:src="marvinURL"
+      >marvin</iframe
+    >
     <br />
     <b-button
       variant="secondary"

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -81,19 +81,19 @@ export default {
     window.addEventListener(
       "message",
       function(event) {
+        if (
+          event.data === "marvinLoaded" &&
+          self.$store.state.compound.mrvfile
+        ) {
+          self.loadMrvfile();
+        }
         if (event.data.type == "returnMrvfile") {
           self.mrvfile = event.data.mrvfile;
-          this.mrvfile = this.$store.state.compound.mrvfile;
+          this.mrvfile = self.$store.state.compound.mrvfile;
         }
       },
       false
     );
-    if (this.$store.state.compound.mrvfile !== "") {
-      const load = this.loadMrvfile;
-      setTimeout(function(){
-        load();
-      }, 300)
-    }
   }
 };
 </script>

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -1,16 +1,16 @@
 <template>
   <div>
-    <iframe id="marvin" class="marvin" data-cy="marvin" v-bind:src="marvinURL"
-      >marvin</iframe
-    >
+    <br />
+    <iframe id="marvin" class="marvin compound" data-cy="marvin" v-bind:src="marvinURL">marvin</iframe>
     <br />
     <b-button
       variant="secondary"
       v-on:click="exportMrvfile"
       style="width:800px"
       id="marvin-export-button"
-      ><b-icon-file-arrow-down></b-icon-file-arrow-down> Export</b-button
     >
+      <b-icon-file-arrow-down></b-icon-file-arrow-down>Export
+    </b-button>
     <b-form-textarea
       id="marvin-import-textarea"
       v-model="mrvfile"
@@ -26,12 +26,15 @@
       class="mt-2"
       style="width:800px"
       id="marvin-import-button"
-      ><b-icon-file-arrow-up></b-icon-file-arrow-up> Import</b-button
     >
+      <b-icon-file-arrow-up></b-icon-file-arrow-up>Import
+    </b-button>
   </div>
 </template>
 
 <script>
+// import onElementReady from "../utils/onElementReady";
+
 export default {
   name: "MarvinWindow",
   data() {
@@ -48,6 +51,15 @@ export default {
           { type: "importMrvfile", mrvfile: this.mrvfile },
           "*"
         );
+    },
+    loadMrvfile: function() {
+      document.getElementById("marvin").contentWindow.postMessage(
+        {
+          type: "importMrvfile",
+          mrvfile: this.$store.state.compound.mrvfile
+        },
+        "*"
+      );
     },
     exportMrvfile: function() {
       document
@@ -66,6 +78,13 @@ export default {
       },
       false
     );
+    if (this.$store.state.compound.mrvfile !== "") {
+      const load = this.loadMrvfile; // lexical this, goes away in setTimeout!
+      setTimeout(function() {
+        load();
+      }, 300); // there is a bit of lag to get the .marvin element to load, thus, the timeout.
+      this.mrvfile = this.$store.state.compound.mrvfile;
+    }
   }
 };
 </script>

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -1,7 +1,13 @@
 <template>
   <div>
     <br />
-    <iframe id="marvin" class="marvin compound" data-cy="marvin" v-bind:src="marvinURL">marvin</iframe>
+    <iframe
+      id="marvin"
+      class="marvin compound"
+      data-cy="marvin"
+      v-bind:src="marvinURL"
+      >marvin</iframe
+    >
     <br />
     <b-button
       variant="secondary"

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -58,7 +58,7 @@ export default {
         },
         "*"
       );
-      this.mrvfile = this.$store.state.compound.mrvfile;
+      this.exportMrvfile();
     },
     exportMrvfile: function() {
       document

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -17,7 +17,6 @@
           v-if="username"
           placeholder="Search Compounds (cid or inchikey)"
         />
-
         <b-button
           class="mr-2"
           variant="dark"

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-navbar toggleable="lg" type="dark" variant="primary" class="shadow mb-5">
+  <b-navbar toggleable="lg" type="dark" variant="primary" class="shadow mb-2">
     <router-link :to="{ name: 'home' }">
       <b-navbar-brand>
         <ChemregLogo color="white" size="35px" />

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,10 +10,14 @@
       <b-navbar-nav>
         <b-nav-item :to="{ name: 'about' }">About</b-nav-item>
       </b-navbar-nav>
+      <b-form-input
+        class="search ml-auto"
+        v-model="text"
+        v-if="username"
+        placeholder="Search Compounds"
+      />
       <b-navbar-nav class="ml-auto">
-        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated"
-          >Login</b-nav-item
-        >
+        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated">Login</b-nav-item>
         <b-nav-item-dropdown name="user-profile" right v-if="username">
           <template v-slot:button-content>
             <span>
@@ -21,9 +25,7 @@
               {{ username }}
             </span>
           </template>
-          <b-dropdown-item name="logout" @click="logout"
-            >Log Out</b-dropdown-item
-          >
+          <b-dropdown-item name="logout" @click="logout">Log Out</b-dropdown-item>
         </b-nav-item-dropdown>
       </b-navbar-nav>
     </b-collapse>
@@ -36,6 +38,9 @@ import ChemregLogo from "@/components/ChemregLogo";
 
 export default {
   name: "NavBar",
+  props: {
+    text: String
+  },
   computed: {
     ...mapState("auth", ["username"]),
     ...mapGetters("auth", ["isAuthenticated"])
@@ -54,5 +59,8 @@ export default {
 <style scoped>
 img {
   margin-right: 5px;
+}
+.search {
+  width: 30%;
 }
 </style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -16,6 +16,7 @@
           v-model="searchString"
           v-if="username"
           placeholder="Search Compounds (cid or inchikey)"
+          data-cy="search-box"
         />
         <b-button
           class="mr-2"
@@ -23,19 +24,20 @@
           @click="searchCompound"
           v-if="username"
           :disabled="searchString.length == 0"
+          data-cy="search-button"
         >
           <b-icon icon="search" />
         </b-button>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
-        <b-nav-item-dropdown name="user-profile" right v-if="username">
+        <b-nav-item-dropdown name="user-profile" right v-if="username" data-cy="user-dropdown">
           <template v-slot:button-content>
             <span>
               <b-icon icon="person-fill" />
               {{ username }}
             </span>
           </template>
-          <b-dropdown-item name="logout" @click="logout">Log Out</b-dropdown-item>
+          <b-dropdown-item name="logout" @click="logout" data-cy="logout-button">Log Out</b-dropdown-item>
         </b-nav-item-dropdown>
       </b-navbar-nav>
     </b-collapse>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,14 +1,14 @@
 <template>
   <b-navbar toggleable="lg" type="dark" variant="primary" class="shadow mb-2">
-    <router-link :to="{ name: 'home' }">
+    <component :is="isAuthenticated ? 'router-link' : 'span'" :to="{ name: 'home' }">
       <b-navbar-brand>
         <ChemregLogo color="white" size="35px" />
       </b-navbar-brand>
-    </router-link>
+    </component>
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
     <b-collapse id="nav-collapse" is-nav>
       <b-navbar-nav>
-        <b-nav-item :to="{ name: 'about' }">About</b-nav-item>
+        <b-nav-item :to="{ name: 'about' }"  v-if="isAuthenticated">About</b-nav-item>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
         <b-form-input

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -12,10 +12,19 @@
       </b-navbar-nav>
       <b-form-input
         class="search ml-auto"
-        v-model="text"
+        v-model="searchString"
         v-if="username"
-        placeholder="Search Compounds"
+        placeholder="Search Compounds (cid or inchikey)"
       />
+      <b-button
+        class="ml-2"
+        variant="dark"
+        @click="searchCompound"
+        v-if="username"
+        :disabled="searchString.length == 0"
+      >
+        <b-icon icon="search" />
+      </b-button>
       <b-navbar-nav class="ml-auto">
         <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated">Login</b-nav-item>
         <b-nav-item-dropdown name="user-profile" right v-if="username">
@@ -38,8 +47,10 @@ import ChemregLogo from "@/components/ChemregLogo";
 
 export default {
   name: "NavBar",
-  props: {
-    text: String
+  data: function() {
+    return {
+      searchString: ""
+    };
   },
   computed: {
     ...mapState("auth", ["username"]),
@@ -48,6 +59,9 @@ export default {
   methods: {
     logout: function() {
       this.$store.dispatch("auth/logout");
+    },
+    searchCompound: function() {
+      this.$store.dispatch("compound/fetchCompound", this.searchString);
     }
   },
   components: {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -10,25 +10,26 @@
       <b-navbar-nav>
         <b-nav-item :to="{ name: 'about' }">About</b-nav-item>
       </b-navbar-nav>
-      <b-form-input
-        class="search ml-auto"
-        v-model="searchString"
-        v-if="username"
-        placeholder="Search Compounds (cid or inchikey)"
-      />
-      <b-button
-        class="ml-2"
-        variant="dark"
-        @click="searchCompound"
-        v-if="username"
-        :disabled="searchString.length == 0"
-      >
-        <b-icon icon="search" />
-      </b-button>
       <b-navbar-nav class="ml-auto">
-        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated"
-          >Login</b-nav-item
+        <b-form-input
+          class="mr-2 search"
+          v-model="searchString"
+          v-if="username"
+          placeholder="Search Compounds (cid or inchikey)"
+        />
+
+        <b-button
+          class="mr-2"
+          variant="dark"
+          @click="searchCompound"
+          v-if="username"
+          :disabled="searchString.length == 0"
         >
+          <b-icon icon="search" />
+        </b-button>
+      </b-navbar-nav>
+      <b-navbar-nav class="ml-auto">
+        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated">Login</b-nav-item>
         <b-nav-item-dropdown name="user-profile" right v-if="username">
           <template v-slot:button-content>
             <span>
@@ -36,9 +37,7 @@
               {{ username }}
             </span>
           </template>
-          <b-dropdown-item name="logout" @click="logout"
-            >Log Out</b-dropdown-item
-          >
+          <b-dropdown-item name="logout" @click="logout">Log Out</b-dropdown-item>
         </b-nav-item-dropdown>
       </b-navbar-nav>
     </b-collapse>
@@ -79,6 +78,6 @@ img {
   margin-right: 5px;
 }
 .search {
-  width: 30%;
+  width: 311px;
 }
 </style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -17,6 +17,7 @@
           v-if="username"
           placeholder="Search Compounds (cid or inchikey)"
           data-cy="search-box"
+          @keyup.enter="searchCompound"
         />
         <b-button
           class="mr-2"

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -8,7 +8,7 @@
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
     <b-collapse id="nav-collapse" is-nav>
       <b-navbar-nav>
-        <b-nav-item :to="{ name: 'about' }"  v-if="isAuthenticated">About</b-nav-item>
+        <b-nav-item :to="{ name: 'about' }" v-if="isAuthenticated">About</b-nav-item>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
         <b-form-input
@@ -28,7 +28,6 @@
         </b-button>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
-        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated">Login</b-nav-item>
         <b-nav-item-dropdown name="user-profile" right v-if="username">
           <template v-slot:button-content>
             <span>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,6 +1,9 @@
 <template>
   <b-navbar toggleable="lg" type="dark" variant="primary" class="shadow mb-2">
-    <component :is="isAuthenticated ? 'router-link' : 'span'" :to="{ name: 'home' }">
+    <component
+      :is="isAuthenticated ? 'router-link' : 'span'"
+      :to="{ name: 'home' }"
+    >
       <b-navbar-brand>
         <ChemregLogo color="white" size="35px" />
       </b-navbar-brand>
@@ -8,7 +11,9 @@
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
     <b-collapse id="nav-collapse" is-nav>
       <b-navbar-nav>
-        <b-nav-item :to="{ name: 'about' }" v-if="isAuthenticated">About</b-nav-item>
+        <b-nav-item :to="{ name: 'about' }" v-if="isAuthenticated"
+          >About</b-nav-item
+        >
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
         <b-form-input
@@ -31,14 +36,21 @@
         </b-button>
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto">
-        <b-nav-item-dropdown name="user-profile" right v-if="username" data-cy="user-dropdown">
+        <b-nav-item-dropdown
+          name="user-profile"
+          right
+          v-if="username"
+          data-cy="user-dropdown"
+        >
           <template v-slot:button-content>
             <span>
               <b-icon icon="person-fill" />
               {{ username }}
             </span>
           </template>
-          <b-dropdown-item name="logout" @click="logout" data-cy="logout-button">Log Out</b-dropdown-item>
+          <b-dropdown-item name="logout" @click="logout" data-cy="logout-button"
+            >Log Out</b-dropdown-item
+          >
         </b-nav-item-dropdown>
       </b-navbar-nav>
     </b-collapse>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -26,7 +26,9 @@
         <b-icon icon="search" />
       </b-button>
       <b-navbar-nav class="ml-auto">
-        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated">Login</b-nav-item>
+        <b-nav-item :to="{ name: 'login' }" v-if="!isAuthenticated"
+          >Login</b-nav-item
+        >
         <b-nav-item-dropdown name="user-profile" right v-if="username">
           <template v-slot:button-content>
             <span>
@@ -34,7 +36,9 @@
               {{ username }}
             </span>
           </template>
-          <b-dropdown-item name="logout" @click="logout">Log Out</b-dropdown-item>
+          <b-dropdown-item name="logout" @click="logout"
+            >Log Out</b-dropdown-item
+          >
         </b-nav-item-dropdown>
       </b-navbar-nav>
     </b-collapse>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,12 +1,16 @@
 import Vue from "vue";
 import Vuex from "vuex";
 import auth from "./modules/auth";
+import compound from "./modules/compound";
+import alert from "./modules/alert";
 
 Vue.use(Vuex);
 
 const store = new Vuex.Store({
   modules: {
-    auth
+    auth,
+    compound,
+    alert
   }
 });
 

--- a/src/store/modules/alert.js
+++ b/src/store/modules/alert.js
@@ -1,0 +1,40 @@
+const state = {
+  message: "",
+  color: "",
+  dismissCountDown: 0
+};
+
+// getters
+const getters = {};
+
+// actions
+const actions = {
+  alert(context, alert) {
+    context.commit("addAlert", alert);
+  }
+};
+
+// mutations
+const mutations = {
+  addAlert(state, alert) {
+    state.message = alert.message;
+    state.color = alert.color;
+    state.dismissCountDown = alert.dismissCountDown;
+  },
+  setCountdown(state, dismissCountDown) {
+    state.dismissCountDown = dismissCountDown;
+  },
+  clearState(state) {
+    state.message = "";
+    state.color = "";
+    state.dismissCountDown = "";
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  getters,
+  actions,
+  mutations
+};

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -19,9 +19,12 @@ const actions = {
     await HTTP.get("/login/")
       .then(response => commit("setUser", response.data))
       .catch(() => {
+        const b = state.username.length === 0;
         const alert = {
-          message: `${state.username}, you are no longer logged in!`,
-          color: "danger",
+          message: b
+            ? "Please log in..."
+            : `${state.username}, you are no longer logged in!`,
+          color: b ? "success" : "danger",
           dismissCountDown: 4
         };
         commit("setUser", {});
@@ -41,9 +44,15 @@ const actions = {
     router.push("/");
   },
   logout: async ({ commit }) => {
-    await HTTP.delete("/login/");
-    commit("setUser", {});
-    router.push("login");
+    await HTTP.delete("/login/")
+      .then(() => {
+        commit("setUser", {});
+        router.push("login");
+      })
+      .catch(() => {
+        commit("setUser", {});
+        router.push("login");
+      });
   }
 };
 

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -43,15 +43,22 @@ const actions = {
     commit("setUser", response.data);
     router.push("/");
   },
-  logout: async ({ commit }) => {
+  logout: async ({ commit, dispatch }) => {
+    const alert = {
+      message: `${state.username}, you are no longer logged in!`,
+      color: "warning",
+      dismissCountDown: 4
+    };
     await HTTP.delete("/login/")
       .then(() => {
         commit("setUser", {});
         router.push("login");
+        dispatch("alert/alert", alert, { root: true });
       })
       .catch(() => {
         commit("setUser", {});
         router.push("login");
+        dispatch("alert/alert", alert, { root: true });
       });
   }
 };

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -15,13 +15,19 @@ const getters = {
 
 // actions
 const actions = {
-  fetchUser: async ({ commit }) => {
-    try {
-      const response = await HTTP.get("/login/");
-      commit("setUser", response.data);
-    } catch {
-      commit("setUser", {});
-    }
+  fetchUser: async ({ commit, dispatch }) => {
+    await HTTP.get("/login/")
+      .then(response => commit("setUser", response.data))
+      .catch(() => {
+        const alert = {
+          message: `${state.username}, you are no longer logged in!`,
+          color: "danger",
+          dismissCountDown: 4
+        };
+        commit("setUser", {});
+        router.push("login");
+        dispatch("alert/alert", alert, { root: true });
+      });
   },
   login: async ({ commit }, { username, password }) => {
     const response = await HTTP.post(

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -4,7 +4,7 @@ const state = {
   cid: "",
   inchikey: "",
   mrvfile: "",
-  molfileV3000: "",
+  molfile: "",
   type: "definedCompound"
 };
 // actions
@@ -39,7 +39,7 @@ const mutations = {
     state.cid = cid;
     state.inchikey = inchikey;
     state.mrvfile = mrvfile;
-    state.molfileV3000 = molfileV3000;
+    state.molfile = molfileV3000;
   },
   setType(state, type) {
     state.type = type;

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -14,21 +14,25 @@ const actions = {
       searchString.indexOf("-") > 0
         ? "/definedCompounds?filter[inchikey]="
         : "/compounds?filter[cid]=";
-    const response = await HTTP.get(endpoint + searchString);
-    const data = response.data.data;
-    if (data.length > 0) {
-      const obj = data.shift();
-      context.commit("setType", obj.type);
-      context.commit("setCompound", obj.attributes);
-    } else {
-      const alert = {
-        message: `${searchString} not valid`,
-        color: "warning",
-        dismissCountDown: 4
-      };
-      context.commit("setType", "definedCompound");
-      context.dispatch("alert/alert", alert, { root: true });
-    }
+    await HTTP.get(endpoint + searchString)
+      .then(response => {
+        const data = response.data.data;
+        if (data.length > 0) {
+          const obj = data.shift();
+          context.commit("setType", obj.type);
+          context.commit("setCompound", obj.attributes);
+        } else {
+          const alert = {
+            message: `${searchString} not valid`,
+            color: "warning",
+            dismissCountDown: 4
+          };
+          context.commit("setType", "definedCompound");
+          context.dispatch("alert/alert", alert, { root: true });
+        }
+      })
+      // this catch won't likely be used without any permissions set on GET
+      .catch(() => context.dispatch("auth/logout", { root: true }));
   }
 };
 

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -9,7 +9,7 @@ const state = {
 };
 // actions
 const actions = {
-  fetchCompound: async ({commit, dispatch}, searchString) => {
+  fetchCompound: async ({ commit, dispatch }, searchString) => {
     dispatch("auth/fetchUser", null, { root: true });
     const endpoint =
       searchString.indexOf("-") > 0

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -9,7 +9,8 @@ const state = {
 };
 // actions
 const actions = {
-  fetchCompound: async (context, searchString) => {
+  fetchCompound: async ({commit, dispatch}, searchString) => {
+    dispatch("auth/fetchUser", null, { root: true });
     const endpoint =
       searchString.indexOf("-") > 0
         ? "/definedCompounds?filter[inchikey]="
@@ -19,20 +20,20 @@ const actions = {
         const data = response.data.data;
         if (data.length > 0) {
           const obj = data.shift();
-          context.commit("setType", obj.type);
-          context.commit("setCompound", obj.attributes);
+          commit("setType", obj.type);
+          commit("setCompound", obj.attributes);
         } else {
           const alert = {
             message: `${searchString} not valid`,
             color: "warning",
             dismissCountDown: 4
           };
-          context.commit("setType", "definedCompound");
-          context.dispatch("alert/alert", alert, { root: true });
+          commit("setType", "definedCompound");
+          dispatch("alert/alert", alert, { root: true });
         }
       })
       // this catch won't likely be used without any permissions set on GET
-      .catch(() => context.dispatch("auth/logout", { root: true }));
+      .catch(() => dispatch("auth/logout", { root: true }));
   }
 };
 

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -7,12 +7,6 @@ const state = {
   molfileV3000: "",
   type: "definedCompound"
 };
-
-// getters
-// const getters = {
-//   isAuthenticated: state => !(state.username === "")
-// };
-
 // actions
 const actions = {
   fetchCompound: async (context, searchString) => {
@@ -55,7 +49,6 @@ const mutations = {
 export default {
   namespaced: true,
   state,
-  //   getters,
   actions,
   mutations
 };

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -1,0 +1,61 @@
+import { HTTP } from "../http-common";
+
+const state = {
+  cid: "",
+  inchikey: "",
+  mrvfile: "",
+  molfileV3000: "",
+  type: "definedCompound"
+};
+
+// getters
+// const getters = {
+//   isAuthenticated: state => !(state.username === "")
+// };
+
+// actions
+const actions = {
+  fetchCompound: async (context, searchString) => {
+    const endpoint =
+      searchString.indexOf("-") > 0
+        ? "/definedCompounds?filter[inchikey]="
+        : "/compounds?filter[cid]=";
+    const response = await HTTP.get(endpoint + searchString);
+    const data = response.data.data;
+    if (data.length > 0) {
+      const obj = data.shift();
+      context.commit("setType", obj.type);
+      context.commit("setCompound", obj.attributes);
+    } else {
+      const alert = {
+        message: `${searchString} not valid`,
+        color: "warning",
+        dismissCountDown: 4
+      };
+      context.commit("setType", "definedCompound");
+      context.dispatch("alert/alert", alert, { root: true });
+    }
+  }
+};
+
+// mutations
+const mutations = {
+  setCompound(state, obj) {
+    const { cid, inchikey, mrvfile, molfileV3000 } = obj;
+    state.cid = cid;
+    state.inchikey = inchikey;
+    state.mrvfile = mrvfile;
+    state.molfileV3000 = molfileV3000;
+  },
+  setType(state, type) {
+    state.type = type;
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  //   getters,
+  actions,
+  mutations
+};

--- a/tests/e2e/specs/home.js
+++ b/tests/e2e/specs/home.js
@@ -1,5 +1,5 @@
 describe("The home page", () => {
-  before(() => {
+  beforeEach(() => {
     cy.adminLogin();
     cy.visit("/");
   });
@@ -51,5 +51,36 @@ describe("The home page", () => {
               });
           });
       });
+  });
+  it("should load defined compound into ketcher window", () => {
+    cy.get("[data-cy=search-box]").type("DTXCID302000003");
+    cy.get("[data-cy=search-button]").click();
+    cy.get("iframe[id=ketcher]");
+    cy.get("#ketcher-import-textarea")
+      .invoke("val")
+      .should("contain", "Ketcher")
+      .should("contain", "V2000");
+  });
+  it("should load illdefined compound into marvin window", () => {
+    cy.get("[data-cy=search-box]").type("DTXCID502000009");
+    cy.get("[data-cy=search-button]").click();
+    cy.get("iframe[id=marvin]");
+    cy.get("#marvin-import-textarea")
+      .invoke("val")
+      .should("contain", '<cml xmlns="http://www.chemaxon.com"')
+      .should("contain", "<MDocument><MChemicalStruct>");
+  });
+  it("bad search should alert invalidity", () => {
+    cy.get("[data-cy=search-box]").type("compound 47");
+    cy.get("[data-cy=search-button]").click();
+    cy.get("[data-cy=alert-box]").should("contain", "compound 47 not valid");
+  });
+  it("logout should provide message to user", () => {
+    cy.get("[data-cy=user-dropdown]").click();
+    cy.get("[data-cy=logout-button]").click();
+    cy.get("[data-cy=alert-box]").should(
+      "contain",
+      "karyn, you are no longer logged in!"
+    );
   });
 });

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -19,26 +19,20 @@ const wrapper = shallowMount(NavBar, {
       return true
     },
     username: "karyn",
-    // username: {
-    //   get: function () {
-    //     return "karyn"
-    //   },
-    //   set: function (newName) {
-    //     return yourNewName
-    //   }
-    // }
   }
 })
 
-console.log(wrapper.html({
-  pretty: true
-}))
+// To inspect the mounted wrapper:
+// console.log(wrapper.html({
+//   pretty: true
+// }))
 
 describe('NavBar', () => {
-
+  // reference for selectors in .find()
+  // https://vue-test-utils.vuejs.org/api/selectors.html
 
   it('displays a brand logo', () => {
-    expect(wrapper.find(".navbar-brand").exists()).toBe(true)
+    expect(wrapper.find("chemreglogo-stub").exists()).toBe(true) // the logo is being stubbed in
   });
 
   it('displays a search box to an authenticated user', () => {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -10,7 +10,12 @@ const wrapper = shallowMount(NavBar, {
     "b-navbar-toggle",
     "b-navbar-brand",
     "router-link",
-    "router-link"
+    "router-link",
+    "b-form-input",
+    "b-button",
+    "b-nav-item-dropdown",
+    "b-icon",
+    "b-dropdown-item"
   ],
   computed: {
     isAuthenticated() {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -1,0 +1,61 @@
+import Vuex from "vuex";
+import { createLocalVue, mount } from "@vue/test-utils";
+import NavBar from "@/components/NavBar.vue";
+import auth from "../../src/store/modules/auth";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe("NavBar.vue", () => {
+  // let actions;
+  // let state;
+  let store;
+
+  beforeEach(() => {
+    // state = {
+    //   clicks: 2
+    // };
+
+    // actions = {
+    //   moduleActionClick: jest.fn()
+    // };
+
+    store = new Vuex.Store({
+      modules: {
+        auth: {
+          state: auth.state,
+          actions: auth.actions,
+          getters: auth.getters
+        }
+      }
+    });
+  });
+
+  it("provides ability to logout", () => {
+    expect(typeof NavBar.methods.logout).toBe("function");
+  });
+
+  it("dispatches fetchCompound when search button is clicked", async () => {
+    const wrapper = mount(NavBar, {
+      store,
+      localVue,
+      stubs: [
+        "b-navbar",
+        "b-nav-item",
+        "b-navbar-nav",
+        "b-collapse",
+        "b-navbar-toggle",
+        "b-navbar-brand",
+        "router-link",
+        "router-link"
+      ]
+    });
+    console.log(wrapper);
+    wrapper.find("#search-button").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(store.dispatch).toHaveBeenCalledWith("compound/fetchCompound", {
+      msg: "Test Namespaced Dispatch"
+    });
+  });
+});

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -1,61 +1,17 @@
-import Vuex from "vuex";
-import { createLocalVue, mount } from "@vue/test-utils";
+import {
+  shallowMount
+} from "@vue/test-utils";
 import NavBar from "@/components/NavBar.vue";
-import auth from "../../src/store/modules/auth";
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
+const wrapper = shallowMount(NavBar)
 
-describe("NavBar.vue", () => {
-  // let actions;
-  // let state;
-  let store;
+describe('NavBar', () => {
 
-  beforeEach(() => {
-    // state = {
-    //   clicks: 2
-    // };
-
-    // actions = {
-    //   moduleActionClick: jest.fn()
-    // };
-
-    store = new Vuex.Store({
-      modules: {
-        auth: {
-          state: auth.state,
-          actions: auth.actions,
-          getters: auth.getters
-        }
-      }
-    });
+  it('has no search class by default', () => {
+    expect(wrapper.hasClass('search')).to.be.false;
   });
 
   it("provides ability to logout", () => {
     expect(typeof NavBar.methods.logout).toBe("function");
-  });
-
-  it("dispatches fetchCompound when search button is clicked", async () => {
-    const wrapper = mount(NavBar, {
-      store,
-      localVue,
-      stubs: [
-        "b-navbar",
-        "b-nav-item",
-        "b-navbar-nav",
-        "b-collapse",
-        "b-navbar-toggle",
-        "b-navbar-brand",
-        "router-link",
-        "router-link"
-      ]
-    });
-    console.log(wrapper);
-    wrapper.find("#search-button").trigger("click");
-    await wrapper.vm.$nextTick();
-
-    expect(store.dispatch).toHaveBeenCalledWith("compound/fetchCompound", {
-      msg: "Test Namespaced Dispatch"
-    });
   });
 });

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -4,20 +4,45 @@ import {
 import NavBar from "@/components/NavBar.vue";
 
 const wrapper = shallowMount(NavBar, {
-  mocks: {
-    $store: {
-      state: {
-        username: "alice",
-        isAuthenticated: "true"
-      }
-    }
-  },
+  stubs: [
+    "b-navbar",
+    "b-nav-item",
+    "b-navbar-nav",
+    "b-collapse",
+    "b-navbar-toggle",
+    "b-navbar-brand",
+    "router-link",
+    "router-link"
+  ],
+  computed: {
+    isAuthenticated() {
+      return true
+    },
+    username: "karyn",
+    // username: {
+    //   get: function () {
+    //     return "karyn"
+    //   },
+    //   set: function (newName) {
+    //     return yourNewName
+    //   }
+    // }
+  }
 })
+
+console.log(wrapper.html({
+  pretty: true
+}))
 
 describe('NavBar', () => {
 
+
+  it('displays a brand logo', () => {
+    expect(wrapper.find(".navbar-brand").exists()).toBe(true)
+  });
+
   it('displays a search box to an authenticated user', () => {
-    expect(wrapper.find("search").exists()).toBe(true)
+    expect(wrapper.find(".search").exists()).toBe(true)
   });
 
   it("provides ability to logout", () => {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -1,31 +1,17 @@
 import {
   shallowMount,
-  createLocalVue
 } from "@vue/test-utils";
-import Vuex from "vuex";
 import NavBar from "@/components/NavBar.vue";
-import auth from '@/store/modules/auth'
-
-const localVue = createLocalVue()
-localVue.use(Vuex);
-
-const store = new Vuex.Store({
-  computed: {
-    username: "alice",
-    isAuthenticated: "true",
-  },
-  modules: {
-    auth: {
-      state: auth.state,
-      actions: auth.actions,
-      getters: auth.getters
-    },
-  }
-})
 
 const wrapper = shallowMount(NavBar, {
-  store,
-  localVue
+  mocks: {
+    $store: {
+      state: {
+        username: "alice",
+        isAuthenticated: "true"
+      }
+    }
+  },
 })
 
 describe('NavBar', () => {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -1,14 +1,37 @@
 import {
-  shallowMount
+  shallowMount,
+  createLocalVue
 } from "@vue/test-utils";
+import Vuex from "vuex";
 import NavBar from "@/components/NavBar.vue";
+import auth from '@/store/modules/auth'
 
-const wrapper = shallowMount(NavBar)
+const localVue = createLocalVue()
+localVue.use(Vuex);
+
+const store = new Vuex.Store({
+  computed: {
+    username: "alice",
+    isAuthenticated: "true",
+  },
+  modules: {
+    auth: {
+      state: auth.state,
+      actions: auth.actions,
+      getters: auth.getters
+    },
+  }
+})
+
+const wrapper = shallowMount(NavBar, {
+  store,
+  localVue
+})
 
 describe('NavBar', () => {
 
-  it('has no search class by default', () => {
-    expect(wrapper.hasClass('search')).to.be.false;
+  it('displays a search box to an authenticated user', () => {
+    expect(wrapper.find("search").exists()).toBe(true)
   });
 
   it("provides ability to logout", () => {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -1,6 +1,4 @@
-import {
-  shallowMount,
-} from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import NavBar from "@/components/NavBar.vue";
 
 const wrapper = shallowMount(NavBar, {
@@ -16,27 +14,27 @@ const wrapper = shallowMount(NavBar, {
   ],
   computed: {
     isAuthenticated() {
-      return true
+      return true;
     },
-    username: "karyn",
+    username: "karyn"
   }
-})
+});
 
 // To inspect the mounted wrapper:
 // console.log(wrapper.html({
 //   pretty: true
 // }))
 
-describe('NavBar', () => {
+describe("NavBar", () => {
   // reference for selectors in .find()
   // https://vue-test-utils.vuejs.org/api/selectors.html
 
-  it('displays a brand logo', () => {
-    expect(wrapper.find("chemreglogo-stub").exists()).toBe(true) // the logo is being stubbed in
+  it("displays a brand logo", () => {
+    expect(wrapper.find("chemreglogo-stub").exists()).toBe(true); // the logo is being stubbed in
   });
 
-  it('displays a search box to an authenticated user', () => {
-    expect(wrapper.find(".search").exists()).toBe(true)
+  it("displays a search box to an authenticated user", () => {
+    expect(wrapper.find(".search").exists()).toBe(true);
   });
 
   it("provides ability to logout", () => {

--- a/tests/unit/navbar.spec.js
+++ b/tests/unit/navbar.spec.js
@@ -16,19 +16,13 @@ const wrapper = shallowMount(NavBar, {
     isAuthenticated() {
       return true;
     },
-    username: "karyn"
+    username() {
+      return "karyn";
+    }
   }
 });
 
-// To inspect the mounted wrapper:
-// console.log(wrapper.html({
-//   pretty: true
-// }))
-
 describe("NavBar", () => {
-  // reference for selectors in .find()
-  // https://vue-test-utils.vuejs.org/api/selectors.html
-
   it("displays a brand logo", () => {
     expect(wrapper.find("chemreglogo-stub").exists()).toBe(true); // the logo is being stubbed in
   });


### PR DESCRIPTION
- [x] add input to navbar
- [x] create gettter/setter to modify store state for compound
- [x] read-in state's compound value into appropriate window (ketcher/marvin)
- [x] display appropriate window based on compound type

the ketcher container was rewritten for this ticket and will need to be re-built, check the wiki to get the new one up.

A search on inchikey is determined by the string having a`-` dash in it, this is only for a defined compound and will call the API at the `definedCompounds` endpoint whereas a CID will use the `/compounds` endpoint.

This ticket adds a new `compound` module to the Vuex store which gets updated if the search is successful. Also, an `alert` module was added with a component added right below the NavBar in the App.Vue file, this can be triggered by dispatching an action as can be seen in the `auth/fetchUser` or the `compound/fetchCompound` to bring up a dismissible/timed alert element that can be edited and styled in the actions payload object.

Each of the Marvin/Ketcher components use the `mounted` life-cycle hook to load the compound if it exists in the store. There is also a computed property which has a watcher on each to respond to any new search that is done in the navbar.

I've also edited the NavBar to make the links inaccesible if the user is not logged in.
