### PR TITLE
Nash Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,6 +1558,12 @@
         "jest-diff": "^24.3.0"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1620,6 +1626,62 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.34.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        }
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
     },
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
@@ -6369,6 +6431,15 @@
       "dev": true,
       "requires": {
         "globals": "^11.12.0"
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "23.20.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
+      "integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^2.5.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -14121,6 +14192,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-cypress": "^2.10.3",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-vue": "^5.0.0",
+    "eslint-plugin-jest": "^23.20.0",
     "prettier": "^1.19.1",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.0",

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -5,9 +5,11 @@
       id="ketcher"
       class="ketcher"
       data-cy="ketcher"
-      v-bind:src="ketcherURL"
+      :src="ketcherURL"
+      @load="loadMolfile"
       width="800"
       height="600"
+      ref="ketcher"
       >ketcher</iframe
     >
     <b-form-textarea
@@ -34,24 +36,30 @@ export default {
   },
   methods: {
     loadMolfile: function() {
-      document.getElementById("ketcher").contentWindow.postMessage(
-        {
-          type: "importMolfile",
-          molfile: this.$store.state.compound.molfile
-        },
-        "*"
-      );
-      this.exportMolfile();
+      if (this.compound !== "") {
+        this.ketcherFrame.contentWindow.postMessage(
+          {
+            type: "importMolfile",
+            molfile: this.compound
+          },
+          "*"
+        );
+        this.exportMolfile();
+      }
     },
     exportMolfile: function() {
-      document
-        .getElementById("ketcher")
-        .contentWindow.postMessage({ type: "exportMolfile" }, "*");
+      this.ketcherFrame.contentWindow.postMessage(
+        { type: "exportMolfile" },
+        "*"
+      );
     }
   },
   computed: {
     compound: function() {
       return this.$store.state.compound.molfile;
+    },
+    ketcherFrame: function() {
+      return this.$refs.ketcher;
     }
   },
   watch: {
@@ -60,23 +68,15 @@ export default {
     }
   },
   mounted() {
-    let self = this;
     window.addEventListener(
       "message",
-      function(event) {
-        if (event.data.type == "returnMolfile") {
-          self.molfile = event.data.molfile;
+      event => {
+        if (event.data.type === "returnMolfile") {
+          this.molfile = event.data.molfile;
         }
       },
       false
     );
-    if (this.$store.state.compound.molfile !== "") {
-      const load = this.loadMolfile;
-      var iFrame = document.getElementById("ketcher");
-      iFrame.addEventListener("load", function() {
-        load();
-      });
-    }
   }
 };
 </script>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -11,6 +11,13 @@
     <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
     <b-collapse id="nav-collapse" is-nav>
       <b-navbar-nav>
+        <b-nav-item
+          :to="{ name: 'controlled-vocabularies' }"
+          v-if="isAuthenticated"
+          >Vocabularies</b-nav-item
+        >
+      </b-navbar-nav>
+      <b-navbar-nav>
         <b-nav-item :to="{ name: 'about' }" v-if="isAuthenticated"
           >About</b-nav-item
         >

--- a/src/components/vocabulary/VocabularyListTable.vue
+++ b/src/components/vocabulary/VocabularyListTable.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <b-table
+      id="vocabulary-list-table"
+      class="text-left"
+      striped
+      hover
+      :items="vocabularyList"
+      :fields="sourceTableFields"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: "Vocabulary",
+  props: {
+    type: String
+  },
+  data() {
+    return {
+      sourceTableFields: [
+        {
+          key: "attributes.label",
+          label: "Name"
+        },
+        {
+          key: "attributes.shortDescription",
+          label: "Description"
+        }
+      ]
+    };
+  },
+  methods: {
+    getList: function() {
+      this.$store.dispatch("vocabularies/getList", this.type);
+    }
+  },
+  watch: {
+    type: function() {
+      this.getList();
+    }
+  },
+  computed: {
+    vocabularyList: function() {
+      return this.$store.state.vocabularies.list;
+    }
+  },
+  mounted() {
+    this.getList();
+  }
+};
+</script>
+
+<style scoped></style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,17 @@ const routes = [
     }
   },
   {
+    path: "/vocabularies",
+    name: "controlled-vocabularies",
+    component: () =>
+      import(
+        /* webpackChunkName: "ControlledVocabularies" */ "../views/Vocabularies"
+      ),
+    meta: {
+      requiresAuth: true
+    }
+  },
+  {
     path: "/login",
     name: "login",
     component: () => import(/* webpackChunkName: "Login" */ "../views/Login")

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 import auth from "./modules/auth";
 import compound from "./modules/compound";
 import alert from "./modules/alert";
+import vocabularies from "./modules/vocabularies";
 
 Vue.use(Vuex);
 
@@ -10,7 +11,8 @@ const store = new Vuex.Store({
   modules: {
     auth,
     compound,
-    alert
+    alert,
+    vocabularies
   }
 });
 

--- a/src/store/modules/vocabularies.js
+++ b/src/store/modules/vocabularies.js
@@ -1,0 +1,27 @@
+import { HTTP } from "../http-common";
+
+const state = {
+  list: []
+};
+
+const mutations = {
+  storeList(state, payload) {
+    state.list = payload;
+  }
+};
+
+// actions
+const actions = {
+  getList: async (context, resource) => {
+    await HTTP.get("/" + resource).then(response => {
+      context.commit("storeList", response.data.data);
+    });
+  }
+};
+
+export default {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};

--- a/src/views/Vocabularies.vue
+++ b/src/views/Vocabularies.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <Title msg="Controlled Vocabularies" />
+    <div class="row">
+      <div class="col-2 offset-2">
+        <b-form-radio-group
+          id="radio-type-select"
+          class="d-flex flex-fill"
+          v-model="type"
+          :options="types"
+          button-variant="outline-primary btn-light-hover"
+          buttons
+          stacked
+        />
+      </div>
+      <div class="col-6">
+        <VocabularyListTable :type="type" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import VocabularyListTable from "@/components/vocabulary/VocabularyListTable";
+import Title from "@/components/HelloWorld";
+
+export default {
+  name: "Vocabulary",
+  data() {
+    let types = [
+      {
+        text: "QC Levels",
+        value: "qcLevels"
+      },
+      {
+        text: "Query Structure Types",
+        value: "queryStructureTypes"
+      },
+      {
+        text: "Relationship Types",
+        value: "relationshipTypes"
+      },
+      {
+        text: "Sources",
+        value: "sources"
+      },
+      {
+        text: "Substance Types",
+        value: "substanceTypes"
+      },
+      {
+        text: "Synonym Qualities",
+        value: "synonymQualities"
+      },
+      {
+        text: "Synonym Types",
+        value: "synonymTypes"
+      }
+    ];
+    return {
+      types: types,
+      // Set the default type as the first type.
+      type: types[0].value
+    };
+  },
+  components: {
+    VocabularyListTable,
+    Title
+  }
+};
+</script>
+
+<style scoped></style>

--- a/tests/e2e/specs/vocabularies.js
+++ b/tests/e2e/specs/vocabularies.js
@@ -1,0 +1,121 @@
+// Simple test data.  Could me moved into a fixture
+// https://docs.cypress.io/api/commands/fixture.html
+const TYPES = [
+  {
+    text: "QC Levels",
+    value: "qcLevels",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample QC Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Query Structure Types",
+    value: "queryStructureTypes",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Query Structure Type Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Relationship Types",
+    value: "relationshipTypes",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Relationship Type Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Sources",
+    value: "sources",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Source Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Substance Types",
+    value: "substanceTypes",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Substance Type Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Synonym Qualities",
+    value: "synonymQualities",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Synonym Quality Label"
+          }
+        }
+      ]
+    }
+  },
+  {
+    text: "Synonym Types",
+    value: "synonymTypes",
+    response: {
+      data: [
+        {
+          attributes: {
+            label: "sample Synonym Type Label"
+          }
+        }
+      ]
+    }
+  }
+];
+
+describe("The vocabularies page", () => {
+  beforeEach(() => {
+    cy.adminLogin();
+    cy.visit("/vocabularies");
+  });
+  it("should have title", () => {
+    cy.contains("h1", "Controlled Vocabularies");
+  });
+  it("should load all types", () => {
+    cy.wrap(TYPES).each(type => {
+      cy.server();
+      cy.route(type.value, type.response);
+      cy.get("#radio-type-select")
+        .contains(type.text)
+        .get("input[value=" + type.value + "]")
+        .parent()
+        .click()
+        .then(() => {
+          cy.get("#vocabulary-list-table").contains(
+            type.response.data[0].attributes.label
+          );
+        });
+    });
+  });
+});

--- a/tests/unit/.eslintrc.js
+++ b/tests/unit/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  plugins: ["jest"],
+  env: {
+    "jest/globals": true
+  },
+  rules: {
+    "jest/no-disabled-tests": "warn",
+    "jest/no-focused-tests": "error",
+    "jest/no-identical-title": "error",
+    "jest/prefer-to-have-length": "warn",
+    "jest/valid-expect": "error"
+  }
+};

--- a/tests/unit/vocabulary-list-table.spec.js
+++ b/tests/unit/vocabulary-list-table.spec.js
@@ -1,0 +1,118 @@
+import VocabularyListTable from "@/components/vocabulary/VocabularyListTable.vue";
+import { createLocalVue, mount, shallowMount } from "@vue/test-utils";
+import Vuex from "vuex";
+import BootstrapVue from "bootstrap-vue";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(BootstrapVue);
+
+// Mocks for tests
+let wrapper;
+
+let state = {
+  list: [
+    {
+      attributes: {
+        label: "Sample Label",
+        shortDescription: "Sample Description"
+      }
+    }
+  ]
+};
+
+let actions = {
+  getList() {}
+};
+
+let vocabularies = {
+  namespaced: true,
+  state,
+  actions
+};
+
+let store = new Vuex.Store({
+  modules: {
+    vocabularies
+  }
+});
+
+describe("Lifecycle Tests", () => {
+  it("calls getList on mount", () => {
+    const spy = jest.spyOn(VocabularyListTable.methods, "getList");
+    wrapper = shallowMount(VocabularyListTable, {
+      store,
+      localVue
+    });
+    expect(spy).toBeCalled();
+  });
+});
+
+describe("Test Component Functionality", () => {
+  beforeEach(() => {
+    wrapper = mount(VocabularyListTable, {
+      store,
+      localVue,
+      propsData: {
+        type: "sources"
+      }
+    });
+  });
+
+  it("reloads table on prop change", () => {
+    const spy = jest.spyOn(wrapper.vm, "getList");
+    wrapper.setProps({ type: "qcLevels" });
+    expect(spy).toBeCalled();
+  });
+
+  it("has Name and Description table headers", () => {
+    expect(
+      wrapper
+        .findAll("th")
+        .at(0)
+        .text()
+    ).toBe("Name");
+    expect(
+      wrapper
+        .findAll("th")
+        .at(1)
+        .text()
+    ).toBe("Description");
+  });
+
+  it("loads data from vocabularyList", () => {
+    expect(
+      wrapper
+        .findAll("td")
+        .at(0)
+        .text()
+    ).toBe(state.list[0].attributes.label);
+    expect(
+      wrapper
+        .findAll("td")
+        .at(1)
+        .text()
+    ).toBe(state.list[0].attributes.shortDescription);
+
+    let updatedList = {
+      attributes: {
+        label: "New Label",
+        shortDescription: "New Description"
+      }
+    };
+    wrapper.vm.$store.state.vocabularies.list = [updatedList];
+
+    expect(
+      wrapper
+        .findAll("td")
+        .at(0)
+        .text()
+    ).toBe(updatedList.attributes.label);
+    expect(
+      wrapper
+        .findAll("td")
+        .at(1)
+        .text()
+    ).toBe(updatedList.attributes.shortDescription);
+  });
+});


### PR DESCRIPTION
* Add Controlled Vocabulary page

* Add linting

* Change CV type dropdown to a sidebar

* Use title component

* Remove auth check.
This looks like it's being done on the base router and therefore doesnt need to be done on every request

* Minor spacing changes

* Add cypress test for each controlled vocabulary

* Add jest test validating table reloads

* Add test for table headers

* Add test for computed property

* lint

* Add linting rules for jest

* Add jest tests for compound creation and update

* Rework KetcherWindow to use $refs over dom.

Unit testing the iframe for ketcher will be impossible unless we have some way of overwriting
which element the functions are using.  Using the ref code in a computed variable should be
cleaner and allow the overwrite of the target iframe in unit tests.

* Add method tests for ketcher iframe interactions

* Clean up redundant listener

* Lint and move jest linter to unit test directory

* Fixed some bugs related to removing listener on mount

* Remove jquery and vanilla bootstrap requirements.  Lint ketcher window

* update package-lock.json to include eslint-plugin-jest files