### PR TITLE
60 substance page structure types

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -2,7 +2,7 @@
   <div>
     <b-form>
       <KetcherWindow v-show="type === 'definedCompound'" />
-      <MarvinWindow v-show="type === 'illDefinedCompound'" />
+      <MarvinWindow v-show="type !== 'definedCompound'" />
       <div class="my-3">
         <b-button type="submit" variant="primary">Save Compound</b-button>
       </div>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import substanceType from "./modules/substance-type";
 import source from "./modules/source";
 import qcLevel from "./modules/qc-level";
 import list from "./modules/list";
+import queryStructureType from "./modules/query-structure-type";
 
 Vue.use(Vuex);
 
@@ -22,7 +23,8 @@ const store = new Vuex.Store({
     substanceType,
     source,
     qcLevel,
-    list
+    list,
+    queryStructureType
   }
 });
 

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -10,6 +10,7 @@ import illdefinedcompound from "./illdefined-compound";
 const defaultState = () => {
   return {
     count: 0,
+    type: 'none',
     list: []
   };
 };
@@ -37,6 +38,11 @@ let actions = {
         const data = response.data;
         if (data.data.length > 0) {
           const obj = data.data.shift();
+
+          if (obj.type === "definedCompound")
+            commit("setType", obj.type)
+          else
+            commit("setType", obj.relationships.queryStructureType.data.id)
 
           let targetModule = obj.type.toLowerCase();
           commit(`${targetModule}/storeFetch`, {
@@ -73,6 +79,9 @@ let actions = {
 // mutations
 const mutations = {
   ...rootMutations,
+  setType(state, type) {
+    state.type = type
+  },
   clearState(state) {
     Object.assign(state, defaultState());
   }

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -10,7 +10,7 @@ import illdefinedcompound from "./illdefined-compound";
 const defaultState = () => {
   return {
     count: 0,
-    type: 'none',
+    type: "none",
     list: []
   };
 };
@@ -39,10 +39,8 @@ let actions = {
         if (data.data.length > 0) {
           const obj = data.data.shift();
 
-          if (obj.type === "definedCompound")
-            commit("setType", obj.type)
-          else
-            commit("setType", obj.relationships.queryStructureType.data.id)
+          if (obj.type === "definedCompound") commit("setType", obj.type);
+          else commit("setType", obj.relationships.queryStructureType.data.id);
 
           let targetModule = obj.type.toLowerCase();
           commit(`${targetModule}/storeFetch`, {
@@ -80,7 +78,7 @@ let actions = {
 const mutations = {
   ...rootMutations,
   setType(state, type) {
-    state.type = type
+    state.type = type;
   },
   clearState(state) {
     Object.assign(state, defaultState());

--- a/src/store/modules/query-structure-type.js
+++ b/src/store/modules/query-structure-type.js
@@ -1,0 +1,28 @@
+import rootActions from "../actions.js";
+import rootMutations from "../mutations.js";
+
+const state = {
+  loaded: false,
+  count: 0,
+  list: []
+};
+
+// actions
+let actions = {
+  ...rootActions,
+  getResourceURI: () => {
+    return "queryStructureTypes";
+  }
+};
+
+// mutations
+const mutations = {
+  ...rootMutations
+};
+
+export default {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -50,9 +50,11 @@ export default {
     };
   },
   computed: {
+    ...mapState("compound", { compoundType: "type" }),
     ...mapState("compound/definedcompound", { defAttr: "attributes" }),
     ...mapState("compound/illdefinedcompound", { illDefAttr: "attributes", illDefRel: "relationships" }),
     ...mapState("queryStructureType", { qstList: "list" }),
+
     cid: function() {
       if (this.type === "definedCompound")
         return this.defAttr.cid;
@@ -65,15 +67,8 @@ export default {
     }
   },
   watch: {
-    defAttr: function() {
-      // Verify this is loaded.  If it is set it to the type (perhaps we should use a loaded flag)
-      if (this.defAttr.cid)
-        this.type = "definedCompound";
-    },
-    illDefAttr: function() {
-      // Verify this is loaded.  If it is set the type to that queryStructureType
-      if (this.illDefAttr.cid)
-        this.type = this.illDefRel.queryStructureType.data.id;
+    compoundType: function() {
+      this.type = this.compoundType;
     }
   },
   methods: {

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -53,8 +53,7 @@ export default {
     ...mapState("compound", { compoundType: "type" }),
     ...mapState("compound/definedcompound", { defAttr: "attributes" }),
     ...mapState("compound/illdefinedcompound", {
-      illDefAttr: "attributes",
-      illDefRel: "relationships"
+      illDefAttr: "attributes"
     }),
     ...mapState("queryStructureType", { qstList: "list" }),
 

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -46,24 +46,25 @@ export default {
   name: "home",
   data() {
     return {
-      type: 'none'
+      type: "none"
     };
   },
   computed: {
     ...mapState("compound", { compoundType: "type" }),
     ...mapState("compound/definedcompound", { defAttr: "attributes" }),
-    ...mapState("compound/illdefinedcompound", { illDefAttr: "attributes", illDefRel: "relationships" }),
+    ...mapState("compound/illdefinedcompound", {
+      illDefAttr: "attributes",
+      illDefRel: "relationships"
+    }),
     ...mapState("queryStructureType", { qstList: "list" }),
 
     cid: function() {
-      if (this.type === "definedCompound")
-        return this.defAttr.cid;
-      else if (this.type === 'none')
-        return ""
+      if (this.type === "definedCompound") return this.defAttr.cid;
+      else if (this.type === "none") return "";
       return this.illDefAttr.cid;
     },
     options: function() {
-      return this.buildOptions(this.qstList)
+      return this.buildOptions(this.qstList);
     }
   },
   watch: {
@@ -74,8 +75,10 @@ export default {
   methods: {
     buildOptions: function(list) {
       let item;
-      let options = [{ value: 'none', text: "None" },
-      { value: 'definedCompound', text: "Defined Compound" }];
+      let options = [
+        { value: "none", text: "None" },
+        { value: "definedCompound", text: "Defined Compound" }
+      ];
       for (item of list)
         options.push({ value: item.id, text: item.attributes.label });
       return options;

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -30,7 +30,7 @@
             />
           </b-form-group>
         </div>
-        <ChemicalEditors :type="type" />
+        <ChemicalEditors v-show="type !== 'none'" :type="type" />
       </b-col>
     </b-row>
   </b-container>
@@ -46,34 +46,53 @@ export default {
   name: "home",
   data() {
     return {
-      type: "definedCompound",
-      options: [
-        { value: "definedCompound", text: "defined" },
-        { value: "illDefinedCompound", text: "ill-defined" }
-      ]
+      type: 'none'
     };
   },
   computed: {
     ...mapState("compound/definedcompound", { defAttr: "attributes" }),
-    ...mapState("compound/illdefinedcompound", { illDefAttr: "attributes" }),
+    ...mapState("compound/illdefinedcompound", { illDefAttr: "attributes", illDefRel: "relationships" }),
+    ...mapState("queryStructureType", { qstList: "list" }),
     cid: function() {
       if (this.type === "definedCompound")
-        return this.$store.state.compound.definedcompound.attributes.cid;
-      else return this.$store.state.compound.illdefinedcompound.attributes.cid;
+        return this.defAttr.cid;
+      else if (this.type === 'none')
+        return ""
+      return this.illDefAttr.cid;
+    },
+    options: function() {
+      return this.buildOptions(this.qstList)
     }
   },
   watch: {
     defAttr: function() {
-      this.type = "definedCompound";
+      // Verify this is loaded.  If it is set it to the type (perhaps we should use a loaded flag)
+      if (this.defAttr.cid)
+        this.type = "definedCompound";
     },
     illDefAttr: function() {
-      this.type = "illDefinedCompound";
+      // Verify this is loaded.  If it is set the type to that queryStructureType
+      if (this.illDefAttr.cid)
+        this.type = this.illDefRel.queryStructureType.data.id;
+    }
+  },
+  methods: {
+    buildOptions: function(list) {
+      let item;
+      let options = [{ value: 'none', text: "None" },
+      { value: 'definedCompound', text: "Defined Compound" }];
+      for (item of list)
+        options.push({ value: item.id, text: item.attributes.label });
+      return options;
     }
   },
   components: {
     HelloWorld,
     ChemicalEditors,
     SubstanceForm
+  },
+  mounted() {
+    this.$store.dispatch("queryStructureType/getList");
   }
 };
 </script>

--- a/src/views/Vocabularies.vue
+++ b/src/views/Vocabularies.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-  <Title :msg="title" />
+    <Title :msg="title" />
     <div class="row">
       <div class="col-2 offset-1">
         <b-form-radio-group
@@ -64,9 +64,9 @@ export default {
     };
   },
   computed: {
-    title: function () {
+    title: function() {
       let val = this.type;
-      return this.types.find(elem => elem.value === val).text
+      return this.types.find(elem => elem.value === val).text;
     }
   },
   components: {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -4,24 +4,24 @@ let qstResponse = {
       id: 1,
       type: "queryStructureType",
       attributes: {
-        label: "Markush",
+        label: "Markush"
       }
     },
     {
       id: 2,
       type: "queryStructureType",
       attributes: {
-        label: "Ill Defined",
+        label: "Ill Defined"
       }
     }
   ]
-}
+};
 
 describe("The substance page", () => {
   beforeEach(() => {
     cy.adminLogin();
-    cy.server()
-    cy.route("queryStructureTypes", qstResponse)
+    cy.server();
+    cy.route("queryStructureTypes", qstResponse);
     cy.visit("/substance");
   });
   it("should have dropdown", () => {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1,16 +1,39 @@
+let qstResponse = {
+  data: [
+    {
+      id: 1,
+      type: "queryStructureType",
+      attributes: {
+        label: "Markush",
+      }
+    },
+    {
+      id: 2,
+      type: "queryStructureType",
+      attributes: {
+        label: "Ill Defined",
+      }
+    }
+  ]
+}
+
 describe("The substance page", () => {
   beforeEach(() => {
     cy.adminLogin();
+    cy.server()
+    cy.route("queryStructureTypes", qstResponse)
     cy.visit("/substance");
   });
   it("should have dropdown", () => {
-    cy.get("#compound-type-dropdown").contains("defined");
-    cy.get("#compound-type-dropdown").contains("ill-defined");
+    cy.get("#compound-type-dropdown").contains("None");
+    cy.get("#compound-type-dropdown").contains("Defined Compound");
+    cy.get("#compound-type-dropdown").contains("Ill Defined");
+    cy.get("#compound-type-dropdown").contains("Markush");
   });
   it("should toggle ketcher/marvinjs on dropdown", () => {
-    cy.get("#compound-type-dropdown").select("defined");
+    cy.get("#compound-type-dropdown").select("Defined Compound");
     cy.get("iframe[id=ketcher]");
-    cy.get("#compound-type-dropdown").select("ill-defined");
+    cy.get("#compound-type-dropdown").select("Ill Defined");
     cy.get("iframe[id=marvin]");
   });
   it("should load defined compound into ketcher window", () => {


### PR DESCRIPTION
closes #60 

Should be a pretty straight forward pull and load.

If the attributes are updated it will set the "type" on the dropdown to whatever is in `relationships.queryStructureType.data.id` or to `definedCompound`.  I don't like the way I'm finding the cid on the substance page (perhaps I should be using a getter).

Completely removing the editor looks weird to me but it was asked for.