### PR TITLE
58 Ill-Defined Substance Saving

### DIFF
--- a/marvin/editorws.html
+++ b/marvin/editorws.html
@@ -51,7 +51,6 @@
         }
       }
       function exportStructure() {
-        console.log("EXPORTING")
         marvin.sketcherInstance
         .exportStructure("mrv")
         .then(val =>

--- a/marvin/editorws.html
+++ b/marvin/editorws.html
@@ -29,14 +29,7 @@
               );
               break;
             case "exportMrvfile":
-              marvin.sketcherInstance
-                .exportStructure("mrv")
-                .then(val =>
-                  window.parent.postMessage(
-                    { type: "returnMrvfile", mrvfile: val },
-                    "*"
-                  )
-                );
+              exportStructure()
               break;
             case "clearMrvfile":
               marvin.sketcherInstance.clear()
@@ -49,12 +42,24 @@
         if (marvin.Sketch.isSupported()) {
           marvin.sketcherInstance = new marvin.Sketch("sketch");
           marvin.sketcherInstance.setServices(getDefaultServices());
+          marvin.sketcherInstance.on('molchange', () => exportStructure())
           parent.postMessage("marvinLoaded", "*");
         } else {
           alert(
             "Cannot initiate sketcher. Current browser may not support HTML canvas or may run in Compatibility Mode."
           );
         }
+      }
+      function exportStructure() {
+        console.log("EXPORTING")
+        marvin.sketcherInstance
+        .exportStructure("mrv")
+        .then(val =>
+          window.parent.postMessage(
+            { type: "returnMrvfile", mrvfile: val },
+            "*"
+          )
+        );
       }
     </script>
   </head>

--- a/marvin/editorws.html
+++ b/marvin/editorws.html
@@ -51,14 +51,15 @@
         }
       }
       function exportStructure() {
-        marvin.sketcherInstance
-        .exportStructure("mrv")
-        .then(val =>
-          window.parent.postMessage(
-            { type: "returnMrvfile", mrvfile: val },
-            "*"
-          )
-        );
+        if (marvin)
+          marvin.sketcherInstance
+          .exportStructure("mrv")
+          .then(val =>
+            window.parent.postMessage(
+              { type: "returnMrvfile", mrvfile: val },
+              "*"
+            )
+          );
       }
     </script>
   </head>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -2,13 +2,13 @@
   <div>
     <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
     <div v-show="type !== 'definedCompound'">
-      <MarvinWindow
-        ref="marvin"
-        @mrvfileChanged="mrvfileChanged = $event"
-      />
+      <MarvinWindow ref="marvin" @mrvfileChanged="mrvfileChanged = $event" />
       <div class="my-3">
-        <b-button @click="saveIllDefinedCompound" variant="primary" :disabled="!mrvfileChanged"
-        >Save Compound</b-button
+        <b-button
+          @click="saveIllDefinedCompound"
+          variant="primary"
+          :disabled="!mrvfileChanged"
+          >Save Compound</b-button
         >
       </div>
     </div>

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <b-form>
-      <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher "/>
+      <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
       <MarvinWindow v-show="type !== 'definedCompound'" ref="marvin" />
       <div class="my-3">
         <b-button @click="save" variant="primary">Save Compound</b-button>
@@ -25,12 +25,11 @@ export default {
   },
   methods: {
     save: function() {
-      if (this.type === 'definedCompound'){
+      if (this.type === "definedCompound") {
         //todo: this is not going to be implemented on this ticket
         // this.$refs['ketcher'].save()
-      }
-      else {
-        this.$refs['marvin'].save()
+      } else {
+        this.$refs["marvin"].save();
       }
     }
   }

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -27,7 +27,7 @@ export default {
     save: function() {
       // Determine which editor is being saved.
       if (this.type === "definedCompound") {
-        //todo: this is not going to be implemented on this ticket
+        //todo: this needs to be implemented
       } else {
         this.saveIllDefinedCompound();
       }

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -25,11 +25,64 @@ export default {
   },
   methods: {
     save: function() {
+      // Determine which editor is being saved.
       if (this.type === "definedCompound") {
         //todo: this is not going to be implemented on this ticket
-        // this.$refs['ketcher'].save()
       } else {
-        this.$refs["marvin"].save();
+        this.saveIllDefinedCompound();
+      }
+    },
+    saveIllDefinedCompound() {
+      let compoundId = this.$store.state.compound.illdefinedcompound.data.id;
+      // Generic pot body
+      let requestBody = {
+        type: "illDefinedCompound",
+        attributes: {
+          mrvfile: this.$refs["marvin"].mrvfile
+        },
+        relationships: {
+          queryStructureType: {
+            data: {
+              id: this.type,
+              type: "queryStructureType"
+            }
+          }
+        }
+      };
+      if (compoundId) {
+        // if there is an id, patch the currently loaded ill-defined compound.
+        this.$store
+          .dispatch("compound/illdefinedcompound/patch", {
+            id: compoundId,
+            body: { ...requestBody, id: compoundId }
+          })
+          // Handle the errors
+          .catch(err => this.handleError(err));
+      } else {
+        // If there is no id, save the new compound
+        this.$store
+          .dispatch("compound/illdefinedcompound/post", requestBody)
+          .then(response =>
+            // Load the newly created compound.  We could bypass this action by
+            // storing the response but this verifies the compound is the same and
+            // further searches will work
+            this.$store.dispatch("compound/fetchCompound", {
+              searchString: response.data.data.attributes.cid
+            })
+          )
+          // Handle the errors
+          .catch(err => this.handleError(err));
+      }
+    },
+    handleError: function(err) {
+      // Currently alert only can store a single alert.
+      // Only the last alert will be presented.
+      for (let error of err.response.data.errors) {
+        this.$store.dispatch("alert/alert", {
+          message: error.detail,
+          color: "danger",
+          dismissCountDown: 15
+        });
       }
     }
   }

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,18 +1,17 @@
 <template>
   <div>
-    <b-form>
-      <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
+    <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
+    <div v-show="type !== 'definedCompound'">
       <MarvinWindow
-        v-show="type !== 'definedCompound'"
         ref="marvin"
         @mrvfileChanged="mrvfileChanged = $event"
       />
       <div class="my-3">
-        <b-button @click="save" variant="primary" :disabled="!structureChanged"
-          >Save Compound</b-button
+        <b-button @click="saveIllDefinedCompound" variant="primary" :disabled="!mrvfileChanged"
+        >Save Compound</b-button
         >
       </div>
-    </b-form>
+    </div>
   </div>
 </template>
 
@@ -34,23 +33,7 @@ export default {
       mrvfileChanged: false
     };
   },
-  computed: {
-    // the "structureChanged" computed function is meant to return whether
-    // either editor has been updated.  If we split the buttons up into two distinct saves
-    // this will be unnecessary.
-    structureChanged: function() {
-      return this.mrvfileChanged;
-    }
-  },
   methods: {
-    save: function() {
-      // Determine which editor is being saved.
-      if (this.type === "definedCompound") {
-        //todo: this needs to be implemented
-      } else {
-        this.saveIllDefinedCompound();
-      }
-    },
     saveIllDefinedCompound() {
       let compoundId = this.$store.state.compound.illdefinedcompound.data.id;
       // Generic pot body

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -2,9 +2,15 @@
   <div>
     <b-form>
       <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
-      <MarvinWindow v-show="type !== 'definedCompound'" ref="marvin" />
+      <MarvinWindow
+        v-show="type !== 'definedCompound'"
+        ref="marvin"
+        @mrvfileChanged="mrvfileChanged = $event"
+      />
       <div class="my-3">
-        <b-button @click="save" variant="primary">Save Compound</b-button>
+        <b-button @click="save" variant="primary" :disabled="!structureChanged"
+          >Save Compound</b-button
+        >
       </div>
     </b-form>
   </div>
@@ -23,6 +29,19 @@ export default {
   props: {
     type: String
   },
+  data() {
+    return {
+      mrvfileChanged: false
+    };
+  },
+  computed: {
+    // the "structureChanged" computed function is meant to return whether
+    // either editor has been updated.  If we split the buttons up into two distinct saves
+    // this will be unnecessary.
+    structureChanged: function() {
+      return this.mrvfileChanged;
+    }
+  },
   methods: {
     save: function() {
       // Determine which editor is being saved.
@@ -38,7 +57,7 @@ export default {
       let requestBody = {
         type: "illDefinedCompound",
         attributes: {
-          mrvfile: this.$refs["marvin"].mrvfile
+          mrvfile: this.$refs["marvin"].localMrvfile
         },
         relationships: {
           queryStructureType: {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <b-form>
-      <KetcherWindow v-show="type === 'definedCompound'" />
-      <MarvinWindow v-show="type !== 'definedCompound'" />
+      <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher "/>
+      <MarvinWindow v-show="type !== 'definedCompound'" ref="marvin" />
       <div class="my-3">
-        <b-button type="submit" variant="primary">Save Compound</b-button>
+        <b-button @click="save" variant="primary">Save Compound</b-button>
       </div>
     </b-form>
   </div>
@@ -22,6 +22,17 @@ export default {
   },
   props: {
     type: String
+  },
+  methods: {
+    save: function() {
+      if (this.type === 'definedCompound'){
+        //todo: this is not going to be implemented on this ticket
+        // this.$refs['ketcher'].save()
+      }
+      else {
+        this.$refs['marvin'].save()
+      }
+    }
   }
 };
 </script>

--- a/src/components/ControlledVocab.vue
+++ b/src/components/ControlledVocab.vue
@@ -1,22 +1,22 @@
 <template v-if="vocab">
-      <dl>
-        <dt>Name</dt>
-        <dd :id="this.nameLabel" class="mx-4">
-          {{ vocab.attributes.name }}
-        </dd>
-        <dt>Label</dt>
-        <dd :id="this.labelLabel" class="mx-4">
-          {{ vocab.attributes.label }}
-        </dd>
-        <dt>Short Description</dt>
-        <dd :id="this.shortLabel" class="mx-4">
-          {{ vocab.attributes.shortDescription }}
-        </dd>
-        <dt>Long Description</dt>
-        <dd :id="this.longLabel" class="mx-4">
-          {{ vocab.attributes.longDescription }}
-        </dd>
-      </dl>
+  <dl>
+    <dt>Name</dt>
+    <dd :id="this.nameLabel" class="mx-4">
+      {{ vocab.attributes.name }}
+    </dd>
+    <dt>Label</dt>
+    <dd :id="this.labelLabel" class="mx-4">
+      {{ vocab.attributes.label }}
+    </dd>
+    <dt>Short Description</dt>
+    <dd :id="this.shortLabel" class="mx-4">
+      {{ vocab.attributes.shortDescription }}
+    </dd>
+    <dt>Long Description</dt>
+    <dd :id="this.longLabel" class="mx-4">
+      {{ vocab.attributes.longDescription }}
+    </dd>
+  </dl>
 </template>
 <script>
 export default {
@@ -27,17 +27,17 @@ export default {
     }
   },
   computed: {
-    nameLabel : function() {
-      return this.vocab.type + "-name-" + this.vocab.id
+    nameLabel: function() {
+      return this.vocab.type + "-name-" + this.vocab.id;
     },
-    labelLabel : function() {
-      return this.vocab.type + "-label-" + this.vocab.id
+    labelLabel: function() {
+      return this.vocab.type + "-label-" + this.vocab.id;
     },
-    shortLabel : function() {
-      return this.vocab.type + "-short-" + this.vocab.id
+    shortLabel: function() {
+      return this.vocab.type + "-short-" + this.vocab.id;
     },
-    longLabel : function() {
-      return this.vocab.type + "-long-" + this.vocab.id
+    longLabel: function() {
+      return this.vocab.type + "-long-" + this.vocab.id;
     }
   }
 };

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -29,11 +29,11 @@ export default {
   methods: {
     ...mapActions("compound/definedcompound", ["fetchByMolfile"]),
     loadMolfile: function() {
-      if (this.attributes.molfileV3000) {
+      if (this.data?.attributes?.molfileV3000) {
         this.ketcherFrame.contentWindow.postMessage(
           {
             type: "importMolfile",
-            molfile: this.attributes.molfileV3000
+            molfile: this.data.attributes.molfileV3000
           },
           "*"
         );
@@ -54,14 +54,14 @@ export default {
     }
   },
   computed: {
-    ...mapState("compound/definedcompound", ["attributes"]),
+    ...mapState("compound/definedcompound", ["data"]),
     ketcherFrame: function() {
       return this.$refs.ketcher;
     }
   },
   watch: {
-    attributes: function() {
-      if (this.attributes.molfileV3000) {
+    data: function() {
+      if (this.data?.attributes?.molfileV3000) {
         this.loadMolfile();
       }
     },

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -50,6 +50,14 @@ export default {
     },
     clearMarvin: function() {
       this.marvinFrame.contentWindow.postMessage({ type: "clearMrvfile" }, "*");
+    },
+    marvinMessageListeners: function(event) {
+      if (event.data === "marvinLoaded" && this.data?.attributes?.mrvfile) {
+        this.loadMrvfile();
+      }
+      if (event.data.type === "returnMrvfile") {
+        this.mrvfile = event.data.mrvfile;
+      }
     }
   },
   computed: {
@@ -68,21 +76,10 @@ export default {
     }
   },
   mounted() {
-    // let self = this;
-    window.addEventListener(
-      "message",
-      event => {
-        if (event.data === "marvinLoaded" && this.data?.attributes?.mrvfile) {
-          this.loadMrvfile();
-        } else {
-          this.exportMrvfile();
-        }
-        if (event.data.type === "returnMrvfile") {
-          this.mrvfile = event.data.mrvfile;
-        }
-      },
-      false
-    );
+    window.addEventListener("message", this.marvinMessageListeners, false);
+  },
+  destroyed() {
+    window.removeEventListener("message", this.marvinMessageListeners);
   }
 };
 </script>

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -11,36 +11,6 @@
         marvin
       </iframe>
     </div>
-    <!-- todo: These buttons were made to be a stop-gap for search on update.
-      At this point I don't believe they are needed but may contain
-      valuable information.  Delete these when update-search is implemented.-->
-    <!--    <br />-->
-    <!--    <b-button-->
-    <!--      variant="secondary"-->
-    <!--      v-on:click="exportMrvfile"-->
-    <!--      style="width:800px"-->
-    <!--      id="marvin-export-button"-->
-    <!--    >-->
-    <!--      <b-icon-file-arrow-down></b-icon-file-arrow-down>Export-->
-    <!--    </b-button>-->
-    <!--    <b-form-textarea-->
-    <!--      id="marvin-import-textarea"-->
-    <!--      v-model="mrvfile"-->
-    <!--      rows="3"-->
-    <!--      max-rows="6"-->
-    <!--      placeholder="Paste mrvfile to import..."-->
-    <!--      class="mx-auto mt-5"-->
-    <!--      style="width:800px"-->
-    <!--    ></b-form-textarea>-->
-    <!--    <b-button-->
-    <!--      variant="primary"-->
-    <!--      v-on:click="importMrvfile"-->
-    <!--      class="mt-2"-->
-    <!--      style="width:800px"-->
-    <!--      id="marvin-import-button"-->
-    <!--    >-->
-    <!--      <b-icon-file-arrow-up></b-icon-file-arrow-up>Import-->
-    <!--    </b-button>-->
   </div>
 </template>
 

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -22,13 +22,13 @@ export default {
   data() {
     return {
       marvinURL: process.env.VUE_APP_MARVIN_URL + "/editorws.html",
-      mrvfile: ""
+      localMrvfile: ""
     };
   },
   methods: {
     importMrvfile: function() {
       this.marvinFrame.contentWindow.postMessage(
-        { type: "importMrvfile", mrvfile: this.mrvfile },
+        { type: "importMrvfile", mrvfile: this.localMrvfile },
         "*"
       );
     },
@@ -40,7 +40,6 @@ export default {
         },
         "*"
       );
-      this.exportMrvfile();
     },
     exportMrvfile: function() {
       this.marvinFrame.contentWindow.postMessage(
@@ -56,8 +55,19 @@ export default {
         this.loadMrvfile();
       }
       if (event.data.type === "returnMrvfile") {
-        this.mrvfile = event.data.mrvfile;
+        this.updateLocalMrvfile(event.data.mrvfile);
       }
+    },
+    updateLocalMrvfile: function(mrvfile) {
+      // Save the external mrvfile to the local vue instance
+      this.localMrvfile = mrvfile;
+
+      // If the mrvfile is blank (as Marvin returns it)
+      // Todo: handle loaded but unchanged
+      if (this.localMrvfile === "<cml><MDocument></MDocument></cml>")
+        // Emit that there was no change
+        this.$emit("mrvfileChanged", false);
+      else this.$emit("mrvfileChanged", true); // Else emit that there was a change
     }
   },
   computed: {

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -80,9 +80,6 @@ export default {
     },
     clearMarvin: function() {
       this.marvinFrame.contentWindow.postMessage({ type: "clearMrvfile" }, "*");
-    },
-    save: function() {
-
     }
   },
   computed: {

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -75,7 +75,7 @@ export default {
         if (event.data === "marvinLoaded" && this.data?.attributes?.mrvfile) {
           this.loadMrvfile();
         } else {
-          this.exportMrvfile()
+          this.exportMrvfile();
         }
         if (event.data.type === "returnMrvfile") {
           this.mrvfile = event.data.mrvfile;

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -74,6 +74,8 @@ export default {
       event => {
         if (event.data === "marvinLoaded" && this.data?.attributes?.mrvfile) {
           this.loadMrvfile();
+        } else {
+          this.exportMrvfile()
         }
         if (event.data.type === "returnMrvfile") {
           this.mrvfile = event.data.mrvfile;

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -66,7 +66,7 @@ export default {
       this.marvinFrame.contentWindow.postMessage(
         {
           type: "importMrvfile",
-          mrvfile: this.attributes.mrvfile
+          mrvfile: this.data.attributes.mrvfile
         },
         "*"
       );
@@ -80,17 +80,20 @@ export default {
     },
     clearMarvin: function() {
       this.marvinFrame.contentWindow.postMessage({ type: "clearMrvfile" }, "*");
+    },
+    save: function() {
+
     }
   },
   computed: {
-    ...mapState("compound/illdefinedcompound", ["attributes"]),
+    ...mapState("compound/illdefinedcompound", ["data"]),
     marvinFrame: function() {
       return this.$refs.marvin;
     }
   },
   watch: {
-    attributes: function() {
-      if (this.attributes.mrvfile) {
+    data: function() {
+      if (this.data?.attributes?.mrvfile) {
         this.loadMrvfile();
       } else {
         this.clearMarvin();
@@ -102,7 +105,7 @@ export default {
     window.addEventListener(
       "message",
       event => {
-        if (event.data === "marvinLoaded" && this.attributes.mrvfile) {
+        if (event.data === "marvinLoaded" && this.data?.attributes?.mrvfile) {
           this.loadMrvfile();
         }
         if (event.data.type === "returnMrvfile") {

--- a/src/components/lists/ListDetailsForm.vue
+++ b/src/components/lists/ListDetailsForm.vue
@@ -25,7 +25,13 @@
       <b-row class="d-block">
         <div class="m-3">
           <b>Accessibility Type:</b>
-          <b-button id="listAccessibility" class="mx-4" pill variant="outline-secondary" v-b-modal.accessibilityType-modal>
+          <b-button
+            id="listAccessibility"
+            class="mx-4"
+            pill
+            variant="outline-secondary"
+            v-b-modal.accessibilityType-modal
+          >
             <b>{{ accessibilityType.attributes.name }}</b>
           </b-button>
           <b-modal id="accessibilityType-modal" title="Accessibility Type">
@@ -35,7 +41,12 @@
         <div id="types" class="m-3">
           <b>List Types:</b>
           <div class="d-inline" v-for="type in listTypes" :key="type.id">
-            <b-button class="mx-4" pill variant="outline-secondary" v-b-modal="type.id">
+            <b-button
+              class="mx-4"
+              pill
+              variant="outline-secondary"
+              v-b-modal="type.id"
+            >
               <b>{{ type.attributes.name }}</b>
             </b-button>
             <b-modal :id="type.id" title="List Type">
@@ -57,12 +68,12 @@ export default {
     ControlledVocab
   },
   computed: {
-    ...mapGetters("list", [ "getIncluded" ]),
+    ...mapGetters("list", ["getIncluded"]),
     id: function() {
       return this.$route.params.id;
     },
     data: function() {
-      return  this.$store.state.list.data ?? {};
+      return this.$store.state.list.data ?? {};
     },
     listTypes: function() {
       return this.getIncluded("types");

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -28,5 +28,12 @@ export default {
       console.exception("Did you define getResourceURI action on your module?");
 
     return HTTP.patch(`/${resource}/${id}`, { data: { ...body } });
+  },
+  post: async (context, body) => {
+    let resource = await context.dispatch("getResourceURI");
+    if (!resource)
+      console.error("Did you define getResourceURI action on your module?");
+
+    return HTTP.post(`/${resource}`, { data: { ...body } });
   }
 };

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -31,21 +31,13 @@ export function substanceFormFromRelationship(state) {
     substanceTypeID: ""
   };
 
-  if (
-    !(
-      state.relationships &&
-      state.relationships.substance &&
-      state.relationships.substance.data
-    )
-  ) {
-    return blankForm;
-  }
-  let type = state.relationships.substance.data.type;
-  let id = state.relationships.substance.data.id;
+  if (!state.data?.relationships?.substance?.data) return blankForm;
+
+  let type = state.data.relationships.substance.data.type;
+  let id = state.data.relationships.substance.data.id;
 
   // Resource not found in includes.  Return blank
-  if (!(state.included && state.included[type] && state.included[type][id]))
-    return blankForm;
+  if (!state.included?.[type]?.[id]) return blankForm;
 
   let attributes = state.included[type][id].attributes;
   let relationships = state.included[type][id].relationships;

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -1,18 +1,22 @@
 export default {
-  getIncluded: (state) => (type) => {
+  getIncluded: state => type => {
     let these = [];
     let obj;
-    if (state.data.relationships[type]){
+    if (state.data.relationships[type]) {
       obj = state.data.relationships[type].data;
     } else {
       obj = [];
     }
-    if (Array.isArray(obj)){
-      for (let o of obj){
-        these.push({"id":o.id, "type": o.type, ...state.included[o.type][o.id]});
+    if (Array.isArray(obj)) {
+      for (let o of obj) {
+        these.push({ id: o.id, type: o.type, ...state.included[o.type][o.id] });
       }
     } else {
-      these = {"id":obj.id, "type": obj.type, ...state.included[obj.type][obj.id]}
+      these = {
+        id: obj.id,
+        type: obj.type,
+        ...state.included[obj.type][obj.id]
+      };
     }
     return these;
   }

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -43,10 +43,7 @@ let actions = {
           else commit("setType", obj.relationships.queryStructureType.data.id);
 
           let targetModule = obj.type.toLowerCase();
-          commit(`${targetModule}/storeFetch`, {
-            attributes: obj.attributes,
-            relationships: obj.relationships
-          });
+          commit(`${targetModule}/storeFetch`, obj);
           commit(`${targetModule}/storeIncluded`, data.included);
         } else {
           const alert = {

--- a/src/store/modules/defined-compound.js
+++ b/src/store/modules/defined-compound.js
@@ -5,8 +5,7 @@ import { HTTP } from "@/store/http-common";
 
 const defaultState = () => {
   return {
-    attributes: {},
-    relationships: {},
+    data: {},
     included: {}
   };
 };

--- a/src/store/modules/illdefined-compound.js
+++ b/src/store/modules/illdefined-compound.js
@@ -4,8 +4,7 @@ import { substanceFormFromRelationship } from "../getters";
 
 const defaultState = () => {
   return {
-    attributes: {},
-    relationships: {},
+    data: {},
     included: {}
   };
 };

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -19,10 +19,12 @@ const state = defaultState();
 let actions = {
   ...rootActions,
   async getObject(context, id) {
-    await HTTP.get(`/lists/${id}?include=listAccessibility,types`).then(response => {
-      context.commit("setAttributes", response.data);
-      context.commit("storeIncluded", response.data.included);
-    });
+    await HTTP.get(`/lists/${id}?include=listAccessibility,types`).then(
+      response => {
+        context.commit("setAttributes", response.data);
+        context.commit("storeIncluded", response.data.included);
+      }
+    );
   },
   getResourceURI: () => {
     return "lists";

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -11,15 +11,11 @@ export default {
       for (let resource of payload) {
         if (state.included[resource.type] === undefined)
           state.included[resource.type] = {};
-        state.included[resource.type][resource.id] = {
-          attributes: resource.attributes,
-          relationships: resource.relationships
-        };
+        state.included[resource.type][resource.id] = resource;
       }
     }
   },
-  storeFetch(state, { attributes, relationships }) {
-    state.attributes = attributes;
-    state.relationships = relationships;
+  storeFetch(state, data) {
+    state.data = data;
   }
 };

--- a/src/views/ListDetails.vue
+++ b/src/views/ListDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container>
     <Title :msg="message" />
-      <hr>
+    <hr />
     <ListDetailsForm />
   </b-container>
 </template>
@@ -19,7 +19,7 @@ export default {
   computed: {
     message: function() {
       let listName = this.$store.state.list.data.attributes?.name ?? "";
-      return  listName + " Details";
+      return listName + " Details";
     }
   }
 };

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -58,7 +58,8 @@ export default {
     ...mapState("queryStructureType", { qstList: "list" }),
 
     cid: function() {
-      if (this.type === "definedCompound") return this.definedCompoundData.attributes?.cid;
+      if (this.type === "definedCompound")
+        return this.definedCompoundData.attributes?.cid;
       else if (this.type === "none") return "";
       return this.illDefinedCompoundData.attributes?.cid;
     },

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -69,7 +69,10 @@ export default {
       return this.buildOptions(this.qstList);
     },
     substanceId: function() {
-      if (this.type === "definedCompound" && this.definedCompoundData.relationships?.substance)
+      if (
+        this.type === "definedCompound" &&
+        this.definedCompoundData.relationships?.substance
+      )
         return this.definedCompoundData.relationships?.substance?.data?.id;
       else if (this.illDefinedCompoundData.relationships?.substance)
         return this.illDefinedCompoundData.relationships?.substance?.data?.id;

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -51,16 +51,16 @@ export default {
   },
   computed: {
     ...mapState("compound", { compoundType: "type" }),
-    ...mapState("compound/definedcompound", { defAttr: "attributes" }),
+    ...mapState("compound/definedcompound", { definedCompoundData: "data" }),
     ...mapState("compound/illdefinedcompound", {
-      illDefAttr: "attributes"
+      illDefinedCompoundData: "data"
     }),
     ...mapState("queryStructureType", { qstList: "list" }),
 
     cid: function() {
-      if (this.type === "definedCompound") return this.defAttr.cid;
+      if (this.type === "definedCompound") return this.definedCompoundData.attributes?.cid;
       else if (this.type === "none") return "";
-      return this.illDefAttr.cid;
+      return this.illDefinedCompoundData.attributes?.cid;
     },
     options: function() {
       return this.buildOptions(this.qstList);

--- a/tests/e2e/specs/list-details.js
+++ b/tests/e2e/specs/list-details.js
@@ -27,29 +27,29 @@ const LIST = {
       }
     },
     included: [
-        {
-            type: "accessibilityType",
-            id: "1",
-            attributes: {
-                name: "new-name",
-                label: "acc type",
-                shortDescription: "this is one of many",
-                longDescription: "",
-                deprecated: true
-            }
-        },
-        {
-            type: "listType",
-            id: "1",
-            attributes: {
-                name: "list-type1",
-                label: "list type1",
-                shortDescription: "this is the first",
-                longDescription: "this will always be the first",
-                deprecated: true
-            }
+      {
+        type: "accessibilityType",
+        id: "1",
+        attributes: {
+          name: "new-name",
+          label: "acc type",
+          shortDescription: "this is one of many",
+          longDescription: "",
+          deprecated: true
         }
-    ],
+      },
+      {
+        type: "listType",
+        id: "1",
+        attributes: {
+          name: "list-type1",
+          label: "list type1",
+          shortDescription: "this is the first",
+          longDescription: "this will always be the first",
+          deprecated: true
+        }
+      }
+    ]
   }
 };
 
@@ -58,7 +58,13 @@ describe("The lists detail page", () => {
     cy.adminLogin();
     cy.server();
 
-    cy.route(LIST.value + "/" + LIST.response.data.id + "?include=listAccessibility,types", LIST.response);
+    cy.route(
+      LIST.value +
+        "/" +
+        LIST.response.data.id +
+        "?include=listAccessibility,types",
+      LIST.response
+    );
 
     cy.visit("/lists/" + LIST.response.data.id);
   });
@@ -66,16 +72,21 @@ describe("The lists detail page", () => {
     cy.contains("h1", "Sample List Name Details");
   });
   it("should load the list details form", () => {
-    cy.get("#list-name-1").should("have.id", "list-name-" + LIST.response.data.id);
+    cy.get("#list-name-1").should(
+      "have.id",
+      "list-name-" + LIST.response.data.id
+    );
     cy.get("#list-name-1").contains(LIST.response.data.attributes.name);
     cy.get("#list-label-1").contains(LIST.response.data.attributes.label);
-    cy.get("#list-short-1").contains(LIST.response.data.attributes.shortDescription);
-    cy.get("#listAccessibility").contains(LIST.response.included[0].attributes.name);
+    cy.get("#list-short-1").contains(
+      LIST.response.data.attributes.shortDescription
+    );
+    cy.get("#listAccessibility").contains(
+      LIST.response.included[0].attributes.name
+    );
     cy.get("#types button")
       .first()
       .invoke("text")
-      .should("deep.equal",
-        LIST.response.included[1].attributes.name
-      );
+      .should("deep.equal", LIST.response.included[1].attributes.name);
   });
 });

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -61,9 +61,9 @@ describe("The substance page", () => {
       .find("text")
       .should("exist");
   });
-  it.only("should post not-loaded illdefined compounds", () => {
+  it("should post not-loaded illdefined compounds", () => {
     // Watch for patches
-    cy.route('POST', '/illDefinedCompounds').as('post')
+    cy.route("POST", "/illDefinedCompounds").as("post");
 
     // Select ill defined compound to access Marvin
     cy.get("#compound-type-dropdown").select("Ill Defined");
@@ -71,65 +71,72 @@ describe("The substance page", () => {
     // Verify marvin has loaded
     cy.get("iframe[id=marvin]")
       .its("0.contentDocument.body")
-      .should("not.be.empty")
+      .should("not.be.empty");
     // Click CycloHexane Button
     cy.get("iframe[id=marvin]")
       .its("0.contentDocument.body")
-      .find('[title=CycloHexane]')
-      .click()
+      .find("[title=CycloHexane]")
+      .click();
     // Add CycloHexane to the canvas
     cy.get("iframe[id=marvin]")
       .its("0.contentDocument.body")
-      .find('canvas#canvas')
-      .click()
+      .find("canvas#canvas")
+      .click();
 
     // Save
-    cy.get("button:contains('Save Compound')").click()
+    cy.get("button:contains('Save Compound')").click();
 
     // Verify patch status and regex for structure
-    cy.get('@post')
-      .should('have.property', 'status', 201)
-    cy.get('@post')
-      .its('request.body.data.attributes.mrvfile')
+    cy.get("@post").should("have.property", "status", 201);
+    cy.get("@post")
+      .its("request.body.data.attributes.mrvfile")
       // This regex accepts only a CycloHexane structure (metadata is excluded from cml tag)
-      .should('match', new RegExp([
-          /<cml.*><MDocument><MChemicalStruct><molecule molID="m1">/
-          ,/<atomArray><atom id="a1" elementType="C" x2="-0.020833333333333037" y2="1.53999998768"\/>/
-          ,/<atom id="a2" elementType="C" x2="-1.3545666559968" y2="0.76999999384"\/>/
-          ,/<atom id="a3" elementType="C" x2="-1.3545666559968" y2="-0.7701866605051737"\/>/
-          ,/<atom id="a4" elementType="C" x2="-0.020833333333333037" y2="-1.5399999876800003"\/>/
-          ,/<atom id="a5" elementType="C" x2="1.3128999893301336" y2="-0.7701866605051737"\/>/
-          ,/<atom id="a6" elementType="C" x2="1.3128999893301336" y2="0.76999999384"\/>/
-          ,/<\/atomArray><bondArray><bond id="b1" atomRefs2="a1 a2" order="1"\/>/
-          ,/<bond id="b2" atomRefs2="a1 a6" order="1"\/><bond id="b3" atomRefs2="a2 a3" order="1"\/>/
-          ,/<bond id="b4" atomRefs2="a3 a4" order="1"\/><bond id="b5" atomRefs2="a4 a5" order="1"\/>/
-          ,/<bond id="b6" atomRefs2="a5 a6" order="1"\/><\/bondArray><\/molecule><\/MChemicalStruct><\/MDocument><\/cml>/
-        ].map(r => { return r.source }).join('')))
+      .should(
+        "match",
+        new RegExp(
+          [
+            /<cml.*><MDocument><MChemicalStruct><molecule molID="m1">/,
+            /<atomArray><atom id="a1" elementType="C" x2="-0.020833333333333037" y2="1.53999998768"\/>/,
+            /<atom id="a2" elementType="C" x2="-1.3545666559968" y2="0.76999999384"\/>/,
+            /<atom id="a3" elementType="C" x2="-1.3545666559968" y2="-0.7701866605051737"\/>/,
+            /<atom id="a4" elementType="C" x2="-0.020833333333333037" y2="-1.5399999876800003"\/>/,
+            /<atom id="a5" elementType="C" x2="1.3128999893301336" y2="-0.7701866605051737"\/>/,
+            /<atom id="a6" elementType="C" x2="1.3128999893301336" y2="0.76999999384"\/>/,
+            /<\/atomArray><bondArray><bond id="b1" atomRefs2="a1 a2" order="1"\/>/,
+            /<bond id="b2" atomRefs2="a1 a6" order="1"\/><bond id="b3" atomRefs2="a2 a3" order="1"\/>/,
+            /<bond id="b4" atomRefs2="a3 a4" order="1"\/><bond id="b5" atomRefs2="a4 a5" order="1"\/>/,
+            /<bond id="b6" atomRefs2="a5 a6" order="1"\/><\/bondArray><\/molecule><\/MChemicalStruct><\/MDocument><\/cml>/
+          ]
+            .map(r => {
+              return r.source;
+            })
+            .join("")
+        )
+      );
   });
   it("should patch loaded illdefined compounds", () => {
     // Watch for patches
-    cy.route('PATCH', '/illDefinedCompounds/**').as('patch')
+    cy.route("PATCH", "/illDefinedCompounds/**").as("patch");
 
     // Verify marvin has loaded
     cy.get("iframe[id=marvin]")
       .its("0.contentDocument.body")
-      .should("not.be.empty")
+      .should("not.be.empty");
 
     // Search
     cy.get("[data-cy=search-box]").type("DTXCID502000009");
     cy.get("[data-cy=search-button]").click();
 
     // Save
-    cy.get("button:contains('Save Compound')").click()
+    cy.get("button:contains('Save Compound')").click();
 
     // Verify patch status and regex for structure
-    cy.get('@patch')
-      .should('have.property', 'status', 200)
-    cy.get('@patch')
-      .its('request.body.data.attributes.mrvfile')
+    cy.get("@patch").should("have.property", "status", 200);
+    cy.get("@patch")
+      .its("request.body.data.attributes.mrvfile")
       // This regex wont accept an empty structure but will accept anything else
       // Verifying the exact structure would make this test brittle
-      .should('match', /(<cml).*(><MDocument>).+(<\/MDocument><\/cml>)/)
+      .should("match", /(<cml).*(><MDocument>).+(<\/MDocument><\/cml>)/);
   });
   it("should fetch from server when ketcher changes", () => {
     cy.get("#compound-type-dropdown").select("Defined Compound");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -63,7 +63,12 @@ describe("The substance page", () => {
   });
   it("should post not-loaded illdefined compounds", () => {
     // Watch for patches
-    cy.route("POST", "/illDefinedCompounds").as("post");
+    cy.route({
+      method: "POST",
+      url: "/illDefinedCompounds",
+      status: 201,
+      response: {}
+    }).as("post");
 
     // Select ill defined compound to access Marvin
     cy.get("#compound-type-dropdown").select("Ill Defined");
@@ -85,7 +90,7 @@ describe("The substance page", () => {
 
     // Save
     cy.get("button:contains('Save Compound')")
-      .should('not.be.disabled')
+      .should("not.be.disabled")
       .click();
 
     // Verify patch status and regex for structure
@@ -118,7 +123,12 @@ describe("The substance page", () => {
   });
   it("should patch loaded illdefined compounds", () => {
     // Watch for patches
-    cy.route("PATCH", "/illDefinedCompounds/**").as("patch");
+    cy.route({
+      method: "PATCH",
+      url: "/illDefinedCompounds/*",
+      status: 200,
+      response: {}
+    }).as("patch");
 
     // Verify marvin has loaded
     cy.get("iframe[id=marvin]")
@@ -131,7 +141,7 @@ describe("The substance page", () => {
 
     // Save
     cy.get("button:contains('Save Compound')")
-      .should('not.be.disabled')
+      .should("not.be.disabled")
       .click();
 
     // Verify patch status and regex for structure

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -84,7 +84,9 @@ describe("The substance page", () => {
       .click();
 
     // Save
-    cy.get("button:contains('Save Compound')").click();
+    cy.get("button:contains('Save Compound')")
+      .should('not.be.disabled')
+      .click();
 
     // Verify patch status and regex for structure
     cy.get("@post").should("have.property", "status", 201);
@@ -128,7 +130,9 @@ describe("The substance page", () => {
     cy.get("[data-cy=search-button]").click();
 
     // Save
-    cy.get("button:contains('Save Compound')").click();
+    cy.get("button:contains('Save Compound')")
+      .should('not.be.disabled')
+      .click();
 
     // Verify patch status and regex for structure
     cy.get("@patch").should("have.property", "status", 200);

--- a/tests/unit/vuex/mutations.spec.js
+++ b/tests/unit/vuex/mutations.spec.js
@@ -56,6 +56,8 @@ describe("test includes mutate properly", () => {
     expect(state.included).toStrictEqual({
       type1: {
         1: {
+          type: "type1",
+          id: 1,
           attributes: {
             attr: "1"
           },
@@ -69,6 +71,8 @@ describe("test includes mutate properly", () => {
           }
         },
         2: {
+          type: "type1",
+          id: 2,
           attributes: {
             attr: "1"
           },
@@ -84,6 +88,8 @@ describe("test includes mutate properly", () => {
       },
       type2: {
         1: {
+          type: "type2",
+          id: 1,
           attributes: {
             attr: "1"
           },

--- a/tests/unit/vuex/substanceForm.spec.js
+++ b/tests/unit/vuex/substanceForm.spec.js
@@ -83,11 +83,13 @@ describe("test get substance form from relationships", () => {
           }
         }
       },
-      relationships: {
-        substance: {
-          data: {
-            type: "substance",
-            id: "1"
+      data: {
+        relationships: {
+          substance: {
+            data: {
+              type: "substance",
+              id: "1"
+            }
           }
         }
       }


### PR DESCRIPTION
closes #58 

This ticket requires a MarvinJS rebuild.  [Information here](https://github.com/Chemical-Curation/chemcurator_vuejs/wiki/Marvin-JS).

Functionality is:

- If an Ill-defined compound is loaded, patch that compound.
- If no compound is loaded, post that compound and reload using the returned CID (to ensure the save worked correctly and pull any defaults into store).

 when the Save Compound button is pressed.  Currently there is no way to save changes to a substance.

This also contains changes to the way modules are saved for compound.  Previously data was separated into attributes and relationships. @debboutr pointed out this strips valuable information for no reason.  As such I've combined the `attributes` and `relationships` keys into the whole response as just `data`.
