### PR TITLE
65 substance page relationships

### DIFF
--- a/src/components/ControlledVocab.vue
+++ b/src/components/ControlledVocab.vue
@@ -1,22 +1,22 @@
 <template v-if="vocab">
-      <dl>
-        <dt>Name</dt>
-        <dd :id="this.nameLabel" class="mx-4">
-          {{ vocab.attributes.name }}
-        </dd>
-        <dt>Label</dt>
-        <dd :id="this.labelLabel" class="mx-4">
-          {{ vocab.attributes.label }}
-        </dd>
-        <dt>Short Description</dt>
-        <dd :id="this.shortLabel" class="mx-4">
-          {{ vocab.attributes.shortDescription }}
-        </dd>
-        <dt>Long Description</dt>
-        <dd :id="this.longLabel" class="mx-4">
-          {{ vocab.attributes.longDescription }}
-        </dd>
-      </dl>
+  <dl>
+    <dt>Name</dt>
+    <dd :id="this.nameLabel" class="mx-4">
+      {{ vocab.attributes.name }}
+    </dd>
+    <dt>Label</dt>
+    <dd :id="this.labelLabel" class="mx-4">
+      {{ vocab.attributes.label }}
+    </dd>
+    <dt>Short Description</dt>
+    <dd :id="this.shortLabel" class="mx-4">
+      {{ vocab.attributes.shortDescription }}
+    </dd>
+    <dt>Long Description</dt>
+    <dd :id="this.longLabel" class="mx-4">
+      {{ vocab.attributes.longDescription }}
+    </dd>
+  </dl>
 </template>
 <script>
 export default {
@@ -27,17 +27,17 @@ export default {
     }
   },
   computed: {
-    nameLabel : function() {
-      return this.vocab.type + "-name-" + this.vocab.id
+    nameLabel: function() {
+      return this.vocab.type + "-name-" + this.vocab.id;
     },
-    labelLabel : function() {
-      return this.vocab.type + "-label-" + this.vocab.id
+    labelLabel: function() {
+      return this.vocab.type + "-label-" + this.vocab.id;
     },
-    shortLabel : function() {
-      return this.vocab.type + "-short-" + this.vocab.id
+    shortLabel: function() {
+      return this.vocab.type + "-short-" + this.vocab.id;
     },
-    longLabel : function() {
-      return this.vocab.type + "-long-" + this.vocab.id
+    longLabel: function() {
+      return this.vocab.type + "-long-" + this.vocab.id;
     }
   }
 };

--- a/src/components/SubstanceRelationshipTable.vue
+++ b/src/components/SubstanceRelationshipTable.vue
@@ -1,0 +1,321 @@
+<template>
+  <div>
+    <div class="text-left">
+      <h3>Substance Relationships</h3>
+    </div>
+    <ag-grid-vue
+      id="substanceRelationshipTable"
+      style="height: 250px;"
+      class="ag-theme-alpine"
+      :columnDefs="columnDefs"
+      :defaultColDef="defaultColDef"
+      :rowData="rowData"
+      :gridOptions="gridOptions"
+      :rowClassRules="rowClassRules"
+      @selection-changed="getSelectedError"
+      rowSelection="single"
+    />
+    <div v-show="selectedError" class="mt-3 text-left">
+      <b-table
+        id="relationship-error-table"
+        :items="selectedError"
+        :fields="errorFields"
+        borderless
+        table-variant="danger"
+      ></b-table>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters, mapState } from "vuex";
+import _ from "lodash";
+import { AgGridVue } from "ag-grid-vue";
+import {
+  MappableCellRenderer,
+  SelectObjectCellEditor
+} from "@/ag-grid-components/custom-renderers";
+
+/**
+ * Render the SID of a substance from a substance relationship
+ * based on whether the provided substance id is in the "to" or "from" substance
+ *
+ * This cell Renderer is specific enough to not be reusable.
+ */
+function SubstanceRelationshipSIDCellRenderer() {}
+SubstanceRelationshipSIDCellRenderer.prototype.init = function(params) {
+  this.eGui = document.createElement("span");
+  if (params.data.relationships.fromSubstance.data.id === params.substanceId) {
+    let substanceData = params.data.relationships.toSubstance.data;
+    this.eGui.innerHTML =
+      params.included[substanceData.type][substanceData.id].attributes.sid;
+  } else {
+    let substanceData = params.data.relationships.fromSubstance.data;
+    this.eGui.innerHTML =
+      params.included[substanceData.type][substanceData.id].attributes.sid;
+  }
+};
+SubstanceRelationshipSIDCellRenderer.prototype.getGui = function() {
+  return this.eGui;
+};
+
+export default {
+  name: "SynonymTable",
+  components: {
+    AgGridVue
+  },
+  props: {
+    // Substance ID to which these synonyms will be related
+    substanceId: String
+  },
+  data() {
+    return {
+      originalData: null,
+      rowData: null,
+      defaultColDef: null,
+      gridOptions: null,
+      // Whether the save / reset buttons are enabled
+      buttonsEnabled: false,
+      // Rows that returned errors on save
+      errorRows: {},
+      // Currently selected error row.  Null if no errors
+      selectedError: null,
+      // Display options for error table.
+      errorFields: [{ label: "Errors", key: "detail" }]
+    };
+  },
+  computed: {
+    ...mapGetters("auth", ["isAuthenticated"]),
+    ...mapState("substanceRelationship", ["list", "loading", "included"]),
+    ...mapState("source", { sourceList: "list" }),
+    ...mapState("relationshipType", { relationshipTypeList: "list" }),
+
+    /**
+     * Defines the columns to be used in ag grid table
+     */
+    columnDefs: function() {
+      return [
+        {
+          headerName: "SID",
+          cellRenderer: SubstanceRelationshipSIDCellRenderer,
+          cellRendererParams: {
+            substanceId: this.substanceId,
+            included: this.included
+          }
+        },
+        {
+          headerName: "Source",
+          field: "relationships.source.data.id",
+          comparator: this.sourceMapCompare,
+          cellRenderer: "mappableCellRenderer",
+          cellRendererParams: {
+            map: this.sourceListMap
+          }
+        },
+        {
+          headerName: "Type",
+          field: "relationships.relationshipType.data.id",
+          comparator: this.typeMapCompare,
+          cellRenderer: "mappableCellRenderer",
+          cellRendererParams: {
+            map: this.typeListMap
+          }
+        },
+        {
+          headerName: "QC Notes",
+          field: "attributes.qcNotes",
+          cellEditor: "agLargeTextCellEditor"
+        }
+      ];
+    },
+
+    /**
+     * Row highlighting rules
+     */
+    rowClassRules: function() {
+      return {
+        // background danger any rows where the id is within the errorRows object
+        "bg-danger": params => {
+          return this.errorRows.hasOwnProperty(params.data.id);
+        }
+      };
+    },
+
+    /**
+     * Synonym objects to be looked up by id.  (used to verify changes)
+     */
+    synonymListMap: function() {
+      let map = {};
+      for (let synonym of this.list) map[synonym.id] = synonym;
+      return map;
+    },
+
+    /**
+     * Source objects to be used in a select dropdown
+     */
+    sourceListOptions: function() {
+      return this.sourceList.map(i => {
+        return { value: i.id, text: i.attributes.label };
+      });
+    },
+
+    /**
+     * Source objects to be looked up by id.  (used in cell renderers from id)
+     */
+    sourceListMap: function() {
+      let map = {};
+      for (let source of this.sourceList) map[source.id] = source;
+      return map;
+    },
+
+    /**
+     * Relationship Type objects to be used in a select dropdown
+     */
+    typeListOptions: function() {
+      return this.relationshipTypeList.map(i => {
+        return { value: i.id, text: i.attributes.label };
+      });
+    },
+
+    /**
+     * Relationship Type objects to be looked up by id.  (used in cell renderers from id)
+     */
+    typeListMap: function() {
+      let map = {};
+      for (let type of this.relationshipTypeList) map[type.id] = type;
+      return map;
+    }
+  },
+  watch: {
+    /**
+     * Loads the relationships for the currently loaded substance
+     */
+    substanceId: function() {
+      if (this.substanceId) this.loadSubstanceRelationships();
+    },
+
+    /**
+     * Handles the AG-Grid loading overlays when synonym loading starts and stops
+     */
+    loading: function() {
+      this.manageOverlay();
+    }
+  },
+  methods: {
+    ...mapActions("alert", ["alert"]),
+    ...mapActions("substanceRelationship", ["getList", "patch"]),
+    ...mapActions("relationshipType", { loadRelationshipTypeList: "getList" }),
+    ...mapActions("source", { loadSourceList: "getList" }),
+
+    /**
+     * Loads synonyms by substance id.
+     */
+    loadSubstanceRelationships: function() {
+      this.getList({
+        params: [
+          { key: "filter[substance.id]", value: this.substanceId },
+          { key: "include", value: "fromSubstance,toSubstance" }
+        ]
+      });
+      this.rowData = _.cloneDeep(this.list);
+    },
+
+    /**
+     * Allows the buttons to be interactive and the overlays to display
+     * based on the state the data is in.
+     */
+    manageOverlay: function() {
+      if (this.loading) {
+        this.gridOptions.api.showLoadingOverlay();
+        this.buttonsEnabled = false;
+      } else if (!this.loading && _.isEqual(this.list, [])) {
+        this.gridOptions.api.showNoRowsOverlay();
+        this.buttonsEnabled = false;
+      } else {
+        this.gridOptions.api.hideOverlay();
+        this.buttonsEnabled = true;
+      }
+    },
+
+    /**
+     * Sets the selected error to the selected row's error.  Otherwise returns null
+     */
+    getSelectedError: function() {
+      this.selectedError =
+        this.errorRows[this.gridOptions?.api.getSelectedRows()[0].id] ?? null;
+    },
+
+    /**
+     * Returns a boolean comparing the map.attribute.labels for two objects
+     *
+     * @param valueA - The id of object 1
+     * @param valueB - The id of object 2
+     * @returns {int} - 1 if object 1's label is first alphabetically otherwise -1
+     */
+    sourceMapCompare: function(valueA, valueB) {
+      let comparison =
+        this.sourceListMap[valueA].attributes.label.toLowerCase() >
+        this.sourceListMap[valueB].attributes.label.toLowerCase();
+      return comparison ? 1 : -1;
+    },
+
+    /**
+     * Returns a boolean comparing the map.attribute.labels for two objects
+     *
+     * @param valueA - The id of object 1
+     * @param valueB - The id of object 2
+     * @returns {int} - 1 if object 1's label is first alphabetically otherwise -1
+     */
+    qualityMapCompare: function(valueA, valueB) {
+      let comparison =
+        this.qualityListMap[valueA].attributes.label.toLowerCase() >
+        this.qualityListMap[valueB].attributes.label.toLowerCase();
+      return comparison ? 1 : -1;
+    },
+
+    /**
+     * Returns a boolean comparing the map.attribute.labels for two objects
+     *
+     * @param valueA - The id of object 1
+     * @param valueB - The id of object 2
+     * @returns {boolean} - 1 if object 1's label is first alphabetically otherwise -1
+     */
+    typeMapCompare: function(valueA, valueB) {
+      let comparison =
+        this.typeListMap[valueA].attributes.label.toLowerCase() >
+        this.typeListMap[valueB].attributes.label.toLowerCase();
+      return comparison ? 1 : -1;
+    }
+  },
+  beforeMount() {
+    // Load grid options
+    this.gridOptions = {
+      components: {
+        mappableCellRenderer: MappableCellRenderer,
+        selectObjectCellEditor: SelectObjectCellEditor
+      }
+    };
+
+    // Load grid styling
+    this.defaultColDef = {
+      flex: 1,
+      editable: this.isAuthenticated,
+      resizable: true,
+      sortable: true
+    };
+  },
+  mounted() {
+    // set the overlay based on the mounted state
+    this.manageOverlay();
+
+    // Load related info
+    this.loadSubstanceRelationships();
+    this.loadRelationshipTypeList();
+    // sources are loaded on the substance page.
+    // This is redundant but will be required if reuse this component.
+    // this.loadSourceList();
+  }
+};
+</script>
+
+<style scoped></style>

--- a/src/components/SubstanceRelationshipTable.vue
+++ b/src/components/SubstanceRelationshipTable.vue
@@ -11,19 +11,7 @@
       :defaultColDef="defaultColDef"
       :rowData="rowData"
       :gridOptions="gridOptions"
-      :rowClassRules="rowClassRules"
-      @selection-changed="getSelectedError"
-      rowSelection="single"
     />
-    <div v-show="selectedError" class="mt-3 text-left">
-      <b-table
-        id="relationship-error-table"
-        :items="selectedError"
-        :fields="errorFields"
-        borderless
-        table-variant="danger"
-      ></b-table>
-    </div>
   </div>
 </template>
 
@@ -70,18 +58,9 @@ export default {
   },
   data() {
     return {
-      originalData: null,
       rowData: null,
       defaultColDef: null,
       gridOptions: null,
-      // Whether the save / reset buttons are enabled
-      buttonsEnabled: false,
-      // Rows that returned errors on save
-      errorRows: {},
-      // Currently selected error row.  Null if no errors
-      selectedError: null,
-      // Display options for error table.
-      errorFields: [{ label: "Errors", key: "detail" }]
     };
   },
   computed: {
@@ -130,33 +109,12 @@ export default {
     },
 
     /**
-     * Row highlighting rules
-     */
-    rowClassRules: function() {
-      return {
-        // background danger any rows where the id is within the errorRows object
-        "bg-danger": params => {
-          return this.errorRows.hasOwnProperty(params.data.id);
-        }
-      };
-    },
-
-    /**
      * Synonym objects to be looked up by id.  (used to verify changes)
      */
-    synonymListMap: function() {
+    substanceRelationshipListMap: function() {
       let map = {};
-      for (let synonym of this.list) map[synonym.id] = synonym;
+      for (let substanceRelationship of this.list) map[substanceRelationship.id] = substanceRelationship;
       return map;
-    },
-
-    /**
-     * Source objects to be used in a select dropdown
-     */
-    sourceListOptions: function() {
-      return this.sourceList.map(i => {
-        return { value: i.id, text: i.attributes.label };
-      });
     },
 
     /**
@@ -166,15 +124,6 @@ export default {
       let map = {};
       for (let source of this.sourceList) map[source.id] = source;
       return map;
-    },
-
-    /**
-     * Relationship Type objects to be used in a select dropdown
-     */
-    typeListOptions: function() {
-      return this.relationshipTypeList.map(i => {
-        return { value: i.id, text: i.attributes.label };
-      });
     },
 
     /**
@@ -188,14 +137,14 @@ export default {
   },
   watch: {
     /**
-     * Loads the relationships for the currently loaded substance
+     * Loads the substance relationships for the currently loaded substance
      */
     substanceId: function() {
       if (this.substanceId) this.loadSubstanceRelationships();
     },
 
     /**
-     * Handles the AG-Grid loading overlays when synonym loading starts and stops
+     * Handles the AG-Grid loading overlays when substance relationship loading starts and stops
      */
     loading: function() {
       this.manageOverlay();
@@ -227,22 +176,11 @@ export default {
     manageOverlay: function() {
       if (this.loading) {
         this.gridOptions.api.showLoadingOverlay();
-        this.buttonsEnabled = false;
       } else if (!this.loading && _.isEqual(this.list, [])) {
         this.gridOptions.api.showNoRowsOverlay();
-        this.buttonsEnabled = false;
       } else {
         this.gridOptions.api.hideOverlay();
-        this.buttonsEnabled = true;
       }
-    },
-
-    /**
-     * Sets the selected error to the selected row's error.  Otherwise returns null
-     */
-    getSelectedError: function() {
-      this.selectedError =
-        this.errorRows[this.gridOptions?.api.getSelectedRows()[0].id] ?? null;
     },
 
     /**
@@ -256,20 +194,6 @@ export default {
       let comparison =
         this.sourceListMap[valueA].attributes.label.toLowerCase() >
         this.sourceListMap[valueB].attributes.label.toLowerCase();
-      return comparison ? 1 : -1;
-    },
-
-    /**
-     * Returns a boolean comparing the map.attribute.labels for two objects
-     *
-     * @param valueA - The id of object 1
-     * @param valueB - The id of object 2
-     * @returns {int} - 1 if object 1's label is first alphabetically otherwise -1
-     */
-    qualityMapCompare: function(valueA, valueB) {
-      let comparison =
-        this.qualityListMap[valueA].attributes.label.toLowerCase() >
-        this.qualityListMap[valueB].attributes.label.toLowerCase();
       return comparison ? 1 : -1;
     },
 
@@ -299,7 +223,6 @@ export default {
     // Load grid styling
     this.defaultColDef = {
       flex: 1,
-      editable: this.isAuthenticated,
       resizable: true,
       sortable: true
     };

--- a/src/components/lists/ListDetailsForm.vue
+++ b/src/components/lists/ListDetailsForm.vue
@@ -25,7 +25,13 @@
       <b-row class="d-block">
         <div class="m-3">
           <b>Accessibility Type:</b>
-          <b-button id="listAccessibility" class="mx-4" pill variant="outline-secondary" v-b-modal.accessibilityType-modal>
+          <b-button
+            id="listAccessibility"
+            class="mx-4"
+            pill
+            variant="outline-secondary"
+            v-b-modal.accessibilityType-modal
+          >
             <b>{{ accessibilityType.attributes.name }}</b>
           </b-button>
           <b-modal id="accessibilityType-modal" title="Accessibility Type">
@@ -35,7 +41,12 @@
         <div id="types" class="m-3">
           <b>List Types:</b>
           <div class="d-inline" v-for="type in listTypes" :key="type.id">
-            <b-button class="mx-4" pill variant="outline-secondary" v-b-modal="type.id">
+            <b-button
+              class="mx-4"
+              pill
+              variant="outline-secondary"
+              v-b-modal="type.id"
+            >
               <b>{{ type.attributes.name }}</b>
             </b-button>
             <b-modal :id="type.id" title="List Type">
@@ -57,12 +68,12 @@ export default {
     ControlledVocab
   },
   computed: {
-    ...mapGetters("list", [ "getIncluded" ]),
+    ...mapGetters("list", ["getIncluded"]),
     id: function() {
       return this.$route.params.id;
     },
     data: function() {
-      return  this.$store.state.list.data ?? {};
+      return this.$store.state.list.data ?? {};
     },
     listTypes: function() {
       return this.getIncluded("types");

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -12,13 +12,15 @@ export default {
     if (request_details && request_details.params) {
       let param;
       for (param of request_details.params) {
-        params_string += `${param.key}=${param.value}`;
+        params_string += `${param.key}=${param.value}&`;
       }
     }
 
     await HTTP.get("/" + resource + params_string).then(response => {
       context.commit("storeList", response.data.data);
       context.commit("storeCount", response.data.meta.pagination.count);
+      if (response.data.included)
+        context.commit("storeIncluded", response.data.included);
     });
     await context.commit("loaded");
   },

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -1,18 +1,22 @@
 export default {
-  getIncluded: (state) => (type) => {
+  getIncluded: state => type => {
     let these = [];
     let obj;
-    if (state.data.relationships[type]){
+    if (state.data.relationships[type]) {
       obj = state.data.relationships[type].data;
     } else {
       obj = [];
     }
-    if (Array.isArray(obj)){
-      for (let o of obj){
-        these.push({"id":o.id, "type": o.type, ...state.included[o.type][o.id]});
+    if (Array.isArray(obj)) {
+      for (let o of obj) {
+        these.push({ id: o.id, type: o.type, ...state.included[o.type][o.id] });
       }
     } else {
-      these = {"id":obj.id, "type": obj.type, ...state.included[obj.type][obj.id]}
+      these = {
+        id: obj.id,
+        type: obj.type,
+        ...state.included[obj.type][obj.id]
+      };
     }
     return these;
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -17,6 +17,8 @@ import user from "./modules/user";
 import externalContact from "./modules/external-contact";
 import listType from "./modules/list-type";
 import queryStructureType from "./modules/query-structure-type";
+import relationshipType from "./modules/relationship-type";
+import substanceRelationship from "./modules/substance-relationship";
 
 Vue.use(Vuex);
 
@@ -38,7 +40,9 @@ const store = new Vuex.Store({
     synonym,
     synonymQuality,
     synonymType,
-    queryStructureType
+    queryStructureType,
+    relationshipType,
+    substanceRelationship
   }
 });
 

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -19,10 +19,12 @@ const state = defaultState();
 let actions = {
   ...rootActions,
   async getObject(context, id) {
-    await HTTP.get(`/lists/${id}?include=listAccessibility,types`).then(response => {
-      context.commit("setAttributes", response.data);
-      context.commit("storeIncluded", response.data.included);
-    });
+    await HTTP.get(`/lists/${id}?include=listAccessibility,types`).then(
+      response => {
+        context.commit("setAttributes", response.data);
+        context.commit("storeIncluded", response.data.included);
+      }
+    );
   },
   getResourceURI: () => {
     return "lists";

--- a/src/store/modules/relationship-type.js
+++ b/src/store/modules/relationship-type.js
@@ -1,0 +1,28 @@
+import rootActions from "../actions.js";
+import rootMutations from "../mutations.js";
+
+const state = {
+  loading: false,
+  count: 0,
+  list: []
+};
+
+// actions
+let actions = {
+  ...rootActions,
+  getResourceURI: () => {
+    return "relationshipTypes";
+  }
+};
+
+// mutations
+const mutations = {
+  ...rootMutations
+};
+
+export default {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};

--- a/src/store/modules/substance-relationship.js
+++ b/src/store/modules/substance-relationship.js
@@ -1,0 +1,29 @@
+import rootActions from "../actions.js";
+import rootMutations from "../mutations.js";
+
+const state = {
+  loading: false,
+  count: 0,
+  list: [],
+  included: {}
+};
+
+// actions
+let actions = {
+  ...rootActions,
+  getResourceURI: () => {
+    return "substanceRelationships";
+  }
+};
+
+// mutations
+const mutations = {
+  ...rootMutations
+};
+
+export default {
+  namespaced: true,
+  state,
+  actions,
+  mutations
+};

--- a/src/views/ListDetails.vue
+++ b/src/views/ListDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container>
     <Title :msg="message" />
-      <hr>
+    <hr />
     <ListDetailsForm />
   </b-container>
 </template>
@@ -19,7 +19,7 @@ export default {
   computed: {
     message: function() {
       let listName = this.$store.state.list.data.attributes?.name ?? "";
-      return  listName + " Details";
+      return listName + " Details";
     }
   }
 };

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -34,6 +34,7 @@
       </b-col>
     </b-row>
     <SynonymTable :substance-id="substanceId" />
+    <SubstanceRelationshipTable :substance-id="substanceId" />
   </b-container>
 </template>
 
@@ -42,6 +43,7 @@ import HelloWorld from "@/components/HelloWorld";
 import ChemicalEditors from "@/components/ChemicalEditors";
 import SubstanceForm from "@/components/SubstanceForm";
 import SynonymTable from "@/components/synonyms/SynonymTable";
+import SubstanceRelationshipTable from "@/components/SubstanceRelationshipTable";
 import { mapState } from "vuex";
 
 export default {
@@ -100,7 +102,8 @@ export default {
     HelloWorld,
     ChemicalEditors,
     SubstanceForm,
-    SynonymTable
+    SynonymTable,
+    SubstanceRelationshipTable
   },
   mounted() {
     this.$store.dispatch("queryStructureType/getList");

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -34,7 +34,7 @@
       </b-col>
     </b-row>
     <SynonymTable :substance-id="substanceId" />
-    <SubstanceRelationshipTable :substance-id="substanceId" />
+    <SubstanceRelationshipTable class="mb-5" :substance-id="substanceId" />
   </b-container>
 </template>
 

--- a/tests/e2e/responses/substance-relationships.json
+++ b/tests/e2e/responses/substance-relationships.json
@@ -1,0 +1,350 @@
+{
+  "links": {
+    "first": "http://localhost:8000/substanceRelationships?filter%5Bsubstance.id%5D=2&include=fromSubstance%2CtoSubstance&page%5Bnumber%5D=1",
+    "last": "http://localhost:8000/substanceRelationships?filter%5Bsubstance.id%5D=2&include=fromSubstance%2CtoSubstance&page%5Bnumber%5D=1",
+    "next": null,
+    "prev": null
+  },
+  "data": [
+    {
+      "type": "substanceRelationship",
+      "id": "1",
+      "attributes": {
+        "qcNotes": "Houston, we have a problem!"
+      },
+      "relationships": {
+        "fromSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/fromSubstance",
+            "related": "http://localhost:8000/substanceRelationships/1/fromSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "2"
+          }
+        },
+        "toSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/toSubstance",
+            "related": "http://localhost:8000/substanceRelationships/1/toSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "3"
+          }
+        },
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/1/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "1"
+          }
+        },
+        "relationshipType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/relationshipType",
+            "related": "http://localhost:8000/substanceRelationships/1/relationshipType"
+          },
+          "data": {
+            "type": "relationshipType",
+            "id": "1"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substanceRelationships/1"
+      }
+    },
+    {
+      "type": "substanceRelationship",
+      "id": "2",
+      "attributes": {
+        "qcNotes": "Houston, we have a problem!"
+      },
+      "relationships": {
+        "fromSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/fromSubstance",
+            "related": "http://localhost:8000/substanceRelationships/2/fromSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "2"
+          }
+        },
+        "toSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/toSubstance",
+            "related": "http://localhost:8000/substanceRelationships/2/toSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "2"
+          }
+        },
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/2/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "1"
+          }
+        },
+        "relationshipType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/relationshipType",
+            "related": "http://localhost:8000/substanceRelationships/2/relationshipType"
+          },
+          "data": {
+            "type": "relationshipType",
+            "id": "1"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substanceRelationships/2"
+      }
+    },
+    {
+      "type": "substanceRelationship",
+      "id": "3",
+      "attributes": {
+        "qcNotes": "Foobar boobar"
+      },
+      "relationships": {
+        "fromSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/fromSubstance",
+            "related": "http://localhost:8000/substanceRelationships/3/fromSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "1"
+          }
+        },
+        "toSubstance": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/toSubstance",
+            "related": "http://localhost:8000/substanceRelationships/3/toSubstance"
+          },
+          "data": {
+            "type": "substance",
+            "id": "2"
+          }
+        },
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/3/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "1"
+          }
+        },
+        "relationshipType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/relationshipType",
+            "related": "http://localhost:8000/substanceRelationships/3/relationshipType"
+          },
+          "data": {
+            "type": "relationshipType",
+            "id": "1"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substanceRelationships/3"
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "substance",
+      "id": "1",
+      "attributes": {
+        "sid": "DTXSID502000000",
+        "preferredName": "Sample Substance",
+        "displayName": "Display Sample Substance",
+        "description": "This is the description for the test substance",
+        "publicQcNote": "Public QC notes",
+        "privateQcNote": "Private QC notes",
+        "casrn": "1234567-89-5"
+      },
+      "relationships": {
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/1/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "1"
+          }
+        },
+        "substanceType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/substanceType",
+            "related": "http://localhost:8000/substanceRelationships/1/substanceType"
+          },
+          "data": {
+            "type": "substanceType",
+            "id": "1"
+          }
+        },
+        "qcLevel": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/qcLevel",
+            "related": "http://localhost:8000/substanceRelationships/1/qcLevel"
+          },
+          "data": {
+            "type": "qcLevel",
+            "id": "1"
+          }
+        },
+        "associatedCompound": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/1/relationships/associatedCompound",
+            "related": "http://localhost:8000/substanceRelationships/1/associatedCompound"
+          },
+          "data": {
+            "type": "definedCompound",
+            "id": "4"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substances/1"
+      }
+    },
+    {
+      "type": "substance",
+      "id": "2",
+      "attributes": {
+        "sid": "DTXSID602000001",
+        "preferredName": "Sample Substance 2",
+        "displayName": "Display Sample Substance 2",
+        "description": "area professor home",
+        "publicQcNote": "this may be acceptable.",
+        "privateQcNote": "Houston, we have a problem!",
+        "casrn": "9876543-21-5"
+      },
+      "relationships": {
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/2/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "2"
+          }
+        },
+        "substanceType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/substanceType",
+            "related": "http://localhost:8000/substanceRelationships/2/substanceType"
+          },
+          "data": {
+            "type": "substanceType",
+            "id": "2"
+          }
+        },
+        "qcLevel": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/qcLevel",
+            "related": "http://localhost:8000/substanceRelationships/2/qcLevel"
+          },
+          "data": {
+            "type": "qcLevel",
+            "id": "1"
+          }
+        },
+        "associatedCompound": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/2/relationships/associatedCompound",
+            "related": "http://localhost:8000/substanceRelationships/2/associatedCompound"
+          },
+          "data": {
+            "type": "illDefinedCompound",
+            "id": "10"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substances/2"
+      }
+    },
+    {
+      "type": "substance",
+      "id": "3",
+      "attributes": {
+        "sid": "DTXSID202000002",
+        "preferredName": "Hydrogen Peroxide",
+        "displayName": "Hydrogen Peroxide",
+        "description": "Hydrogen peroxide is a mild antiseptic used on the skin to prevent infection of minor cuts, scrapes, and burns.",
+        "publicQcNote": "Public QC",
+        "privateQcNote": "Private QC",
+        "casrn": "7722-84-1"
+      },
+      "relationships": {
+        "source": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/source",
+            "related": "http://localhost:8000/substanceRelationships/3/source"
+          },
+          "data": {
+            "type": "source",
+            "id": "2"
+          }
+        },
+        "substanceType": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/substanceType",
+            "related": "http://localhost:8000/substanceRelationships/3/substanceType"
+          },
+          "data": {
+            "type": "substanceType",
+            "id": "1"
+          }
+        },
+        "qcLevel": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/qcLevel",
+            "related": "http://localhost:8000/substanceRelationships/3/qcLevel"
+          },
+          "data": {
+            "type": "qcLevel",
+            "id": "1"
+          }
+        },
+        "associatedCompound": {
+          "links": {
+            "self": "http://localhost:8000/substanceRelationships/3/relationships/associatedCompound",
+            "related": "http://localhost:8000/substanceRelationships/3/associatedCompound"
+          },
+          "data": {
+            "type": "definedCompound",
+            "id": "25"
+          }
+        }
+      },
+      "links": {
+        "self": "http://localhost:8000/substances/3"
+      }
+    }
+  ],
+  "meta": {
+    "pagination": {
+      "page": 1,
+      "pages": 1,
+      "count": 3
+    },
+    "apiVersion": "1.0.0-beta"
+  }
+}

--- a/tests/e2e/specs/list-details.js
+++ b/tests/e2e/specs/list-details.js
@@ -27,29 +27,29 @@ const LIST = {
       }
     },
     included: [
-        {
-            type: "accessibilityType",
-            id: "1",
-            attributes: {
-                name: "new-name",
-                label: "acc type",
-                shortDescription: "this is one of many",
-                longDescription: "",
-                deprecated: true
-            }
-        },
-        {
-            type: "listType",
-            id: "1",
-            attributes: {
-                name: "list-type1",
-                label: "list type1",
-                shortDescription: "this is the first",
-                longDescription: "this will always be the first",
-                deprecated: true
-            }
+      {
+        type: "accessibilityType",
+        id: "1",
+        attributes: {
+          name: "new-name",
+          label: "acc type",
+          shortDescription: "this is one of many",
+          longDescription: "",
+          deprecated: true
         }
-    ],
+      },
+      {
+        type: "listType",
+        id: "1",
+        attributes: {
+          name: "list-type1",
+          label: "list type1",
+          shortDescription: "this is the first",
+          longDescription: "this will always be the first",
+          deprecated: true
+        }
+      }
+    ]
   }
 };
 
@@ -58,7 +58,13 @@ describe("The lists detail page", () => {
     cy.adminLogin();
     cy.server();
 
-    cy.route(LIST.value + "/" + LIST.response.data.id + "?include=listAccessibility,types", LIST.response);
+    cy.route(
+      LIST.value +
+        "/" +
+        LIST.response.data.id +
+        "?include=listAccessibility,types",
+      LIST.response
+    );
 
     cy.visit("/lists/" + LIST.response.data.id);
   });
@@ -66,16 +72,21 @@ describe("The lists detail page", () => {
     cy.contains("h1", "Sample List Name Details");
   });
   it("should load the list details form", () => {
-    cy.get("#list-name-1").should("have.id", "list-name-" + LIST.response.data.id);
+    cy.get("#list-name-1").should(
+      "have.id",
+      "list-name-" + LIST.response.data.id
+    );
     cy.get("#list-name-1").contains(LIST.response.data.attributes.name);
     cy.get("#list-label-1").contains(LIST.response.data.attributes.label);
-    cy.get("#list-short-1").contains(LIST.response.data.attributes.shortDescription);
-    cy.get("#listAccessibility").contains(LIST.response.included[0].attributes.name);
+    cy.get("#list-short-1").contains(
+      LIST.response.data.attributes.shortDescription
+    );
+    cy.get("#listAccessibility").contains(
+      LIST.response.included[0].attributes.name
+    );
     cy.get("#types button")
       .first()
       .invoke("text")
-      .should("deep.equal",
-        LIST.response.included[1].attributes.name
-      );
+      .should("deep.equal", LIST.response.included[1].attributes.name);
   });
 });

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -313,3 +313,40 @@ describe("The substance page's Synonym Table", () => {
       .should("contain.text", "Synonym 1");
   });
 });
+
+describe.only("The substance page's Relationships Table", () => {
+  beforeEach(() => {
+    cy.adminLogin();
+    cy.visit("/substance");
+    cy.server();
+
+    // fixture loading the synonyms
+    cy.route(
+      "GET",
+      "/substanceRelationships?*",
+      "fx:../responses/substance-relationships.json"
+    );
+  });
+
+  it("should show the relationships table", () => {
+    cy.get("#substanceRelationshipTable").should(
+      "contain.text",
+      "No Rows To Show"
+    );
+  });
+
+  it("should load relationships", () => {
+    // Navigate to substance with relationships
+    cy.get("[data-cy=search-box]").type("DTXCID502000009");
+    cy.get("[data-cy=search-button]").click();
+
+    // Verify response contains sids as required.
+    cy.get("#substanceRelationshipTable")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .should("have.length", 3)
+      .should("contain", "DTXSID502000000")
+      .should("contain", "DTXSID602000001")
+      .should("contain", "DTXSID202000002");
+  });
+});

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -314,7 +314,7 @@ describe("The substance page's Synonym Table", () => {
   });
 });
 
-describe.only("The substance page's Relationships Table", () => {
+describe("The substance page's Relationships Table", () => {
   beforeEach(() => {
     cy.adminLogin();
     cy.visit("/substance");


### PR DESCRIPTION
closes #65

This adds an AG-Grid for substance relationships on the substance page.

This is very similar to the synonym table.  I had to use an SID value getter to fetch the correct SID and I also opted to use a custom SID comparison function that disregards the first 8 digits (Typically 'DTXSIDx0' with x as a checksum) as the checksum was making ordering meaningless.

Looks like there was also a fair amount of linting done on this ticket.