### PR TITLE
Remove console.logs that were causing problems building

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -4,8 +4,6 @@ import { HTTP } from "@/store/http-common";
 export default {
   getList: async (context, request_details) => {
     let resource = await context.dispatch("getResourceURI");
-    if (!resource)
-      console.error("Did you define getResourceURI action on your module?");
 
     context.commit("loading");
     let params_string = "?";
@@ -24,8 +22,6 @@ export default {
   },
   patch: async (context, { id, body }) => {
     let resource = await context.dispatch("getResourceURI");
-    if (!resource)
-      console.exception("Did you define getResourceURI action on your module?");
 
     return HTTP.patch(`/${resource}/${id}`, { data: { ...body } });
   }


### PR DESCRIPTION
This is a hotfix that simply removes two comments that I added to actions.js that I didn't realize NPM wouldn't build in production.

**To test build** on **staging-release** build the environment either from **npm**:
  `npm run build`
or using the **vue ui** tool:
  build -> Run Task (verify your Parameters are set to production mode)

On **staging** the output should be:
```
**/chemcurator_vuejs/src/store/actions.js
   8:7  error  Unexpected console statement  no-console
  30:7  error  Unexpected console statement  no-console
```

This branch resolves those issues by removing these console logs that were there to verify a resource URI was provided on the module's actions.