### PR TITLE
55 defined editing

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -1,6 +1,16 @@
 <template>
   <div>
-    <KetcherWindow v-show="type === 'definedCompound'" ref="ketcher " />
+    <div v-show="type === 'definedCompound'">
+      <KetcherWindow ref="ketcher" @molfileChanged="molfileChanged = $event" />
+      <div class="my-3">
+        <b-button
+          @click="saveDefinedCompound"
+          variant="primary"
+          :disabled="!molfileChanged"
+          >Save Defined Compound</b-button
+        >
+      </div>
+    </div>
     <div v-show="type !== 'definedCompound'">
       <MarvinWindow ref="marvin" @mrvfileChanged="mrvfileChanged = $event" />
       <div class="my-3">
@@ -8,7 +18,7 @@
           @click="saveIllDefinedCompound"
           variant="primary"
           :disabled="!mrvfileChanged"
-          >Save Compound</b-button
+          >Save Ill Defined Compound</b-button
         >
       </div>
     </div>
@@ -30,10 +40,46 @@ export default {
   },
   data() {
     return {
+      molfileChanged: false,
       mrvfileChanged: false
     };
   },
   methods: {
+    saveDefinedCompound() {
+      let compoundId = this.$store.state.compound.definedcompound.data.id;
+      // replace is used to escape "\" so that the JSON is parsable
+      let requestBody = {
+        type: "definedCompound",
+        attributes: {
+          molfileV2000: this.$refs["ketcher"].molfile.replace(/\\/g, "\\\\")
+        }
+      };
+      console.log(requestBody);
+      if (compoundId) {
+        // if there is an id, patch the currently loaded defined compound.
+        this.$store
+          .dispatch("compound/definedcompound/patch", {
+            id: compoundId,
+            body: { ...requestBody, id: compoundId }
+          })
+          // Handle the errors
+          .catch(err => this.handleError(err));
+      } else {
+        // If there is no id, save the new compound
+        this.$store
+          .dispatch("compound/definedcompound/post", requestBody)
+          .then(response =>
+            // Load the newly created compound.  We could bypass this action by
+            // storing the response but this verifies the compound is the same and
+            // further searches will work
+            this.$store.dispatch("compound/fetchCompound", {
+              searchString: response.data.data.attributes.cid
+            })
+          )
+          // Handle the errors
+          .catch(err => this.handleError(err));
+      }
+    },
     saveIllDefinedCompound() {
       let compoundId = this.$store.state.compound.illdefinedcompound.data.id;
       // Generic pot body

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -54,7 +54,6 @@ export default {
           molfileV2000: this.$refs["ketcher"].molfile.replace(/\\/g, "\\\\")
         }
       };
-      console.log(requestBody);
       if (compoundId) {
         // if there is an id, patch the currently loaded defined compound.
         this.$store

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -24,6 +24,7 @@ export default {
     return {
       ketcherURL: process.env.VUE_APP_KETCHER_URL,
       initial_molfile: "  0  0  0     0  0            999 V2000\nM  END",
+      blank: "  0  0  0     0  0            999 V2000\nM  END",
       molfile: ""
     };
   },
@@ -61,7 +62,7 @@ export default {
     }
   },
   computed: {
-    ...mapState("compound/definedcompound", ["data", "blank"]),
+    ...mapState("compound/definedcompound", ["data"]),
     ketcherFrame: function() {
       return this.$refs.ketcher;
     }

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -53,8 +53,11 @@ export default {
         "*"
       );
     },
-    removeHeader: function(str){
-      return str.split("\n").slice(3,-1).join("\n");
+    removeHeader: function(str) {
+      return str
+        .split("\n")
+        .slice(3, -1)
+        .join("\n");
     }
   },
   computed: {
@@ -72,7 +75,7 @@ export default {
     molfile: function() {
       this.fetchByMolfile(this.molfile);
       let temp = this.removeHeader(this.molfile);
-      if (temp !== this.initial_molfile){
+      if (temp !== this.initial_molfile) {
         this.$emit("molfileChanged", true);
       } else {
         this.$emit("molfileChanged", false);
@@ -86,11 +89,15 @@ export default {
         if (event.data.type === "returnMolfile") {
           this.molfile = event.data.molfile;
           let init = this.removeHeader(event.data.molfile);
-          if (this.data?.attributes?.molfileV3000 &&
-              this.initial_molfile === this.blank){ // update for search
+          if (
+            this.data?.attributes?.molfileV3000 &&
+            this.initial_molfile === this.blank
+          ) {
+            // update for search
             this.initial_molfile = init;
           }
-          if (init === this.blank){ // update if cleared while editing
+          if (init === this.blank) {
+            // update if cleared while editing
             this.initial_molfile = init;
           }
         }

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -23,6 +23,7 @@ export default {
   data() {
     return {
       ketcherURL: process.env.VUE_APP_KETCHER_URL,
+      initial_molfile: "  0  0  0     0  0            999 V2000\nM  END",
       molfile: ""
     };
   },
@@ -51,10 +52,13 @@ export default {
         { type: "clearMolfile" },
         "*"
       );
+    },
+    removeHeader: function(str){
+      return str.split("\n").slice(3,-1).join("\n");
     }
   },
   computed: {
-    ...mapState("compound/definedcompound", ["data"]),
+    ...mapState("compound/definedcompound", ["data", "blank"]),
     ketcherFrame: function() {
       return this.$refs.ketcher;
     }
@@ -67,6 +71,12 @@ export default {
     },
     molfile: function() {
       this.fetchByMolfile(this.molfile);
+      let temp = this.removeHeader(this.molfile);
+      if (temp !== this.initial_molfile){
+        this.$emit("molfileChanged", true);
+      } else {
+        this.$emit("molfileChanged", false);
+      }
     }
   },
   mounted() {
@@ -75,6 +85,14 @@ export default {
       event => {
         if (event.data.type === "returnMolfile") {
           this.molfile = event.data.molfile;
+          let init = this.removeHeader(event.data.molfile);
+          if (this.data?.attributes?.molfileV3000 &&
+              this.initial_molfile === this.blank){ // update for search
+            this.initial_molfile = init;
+          }
+          if (init === this.blank){ // update if cleared while editing
+            this.initial_molfile = init;
+          }
         }
       },
       false

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -61,18 +61,22 @@ const actions = {
     await HTTP.delete("/login/")
       .then(() => {
         commit("setUser", {});
-        router.push({
-          name: "home"
-        }).catch(() => {});
+        router
+          .push({
+            name: "home"
+          })
+          .catch(() => {});
         dispatch("alert/alert", alert, {
           root: true
         });
       })
       .catch(() => {
         commit("setUser", {});
-        router.push({
-          name: "home"
-        }).catch(() => {});
+        router
+          .push({
+            name: "home"
+          })
+          .catch(() => {});
         dispatch("alert/alert", alert, {
           root: true
         });

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -50,7 +50,7 @@ const actions = {
       }
     );
     commit("setUser", response.data);
-    router.push("/");
+    router.push("/").catch(() => {});
   },
   logout: async ({ commit, dispatch }) => {
     const alert = {
@@ -63,7 +63,7 @@ const actions = {
         commit("setUser", {});
         router.push({
           name: "home"
-        });
+        }).catch(() => {});
         dispatch("alert/alert", alert, {
           root: true
         });
@@ -72,7 +72,7 @@ const actions = {
         commit("setUser", {});
         router.push({
           name: "home"
-        });
+        }).catch(() => {});
         dispatch("alert/alert", alert, {
           root: true
         });

--- a/src/store/modules/defined-compound.js
+++ b/src/store/modules/defined-compound.js
@@ -32,7 +32,8 @@ const actions = {
         commit(`storeFetch`, obj);
         commit(`storeIncluded`, data.included);
       } else {
-        console.log("doin nuthin in fetchByMolfile");
+        // for now, if a compound is found we want to leave it in state to do
+        // a PATCH on it
         // commit("clearState");
       }
     });

--- a/src/store/modules/defined-compound.js
+++ b/src/store/modules/defined-compound.js
@@ -6,8 +6,7 @@ import { HTTP } from "@/store/http-common";
 const defaultState = () => {
   return {
     data: {},
-    included: {},
-    blank: "  0  0  0     0  0            999 V2000\nM  END"
+    included: {}
   };
 };
 

--- a/src/store/modules/defined-compound.js
+++ b/src/store/modules/defined-compound.js
@@ -6,7 +6,8 @@ import { HTTP } from "@/store/http-common";
 const defaultState = () => {
   return {
     data: {},
-    included: {}
+    included: {},
+    blank: "  0  0  0     0  0            999 V2000\nM  END"
   };
 };
 
@@ -15,7 +16,7 @@ const state = defaultState();
 // actions
 const actions = {
   ...rootActions,
-  resourceURI: () => {
+  getResourceURI: () => {
     return "definedCompounds";
   },
   fetchByMolfile: async ({ commit }, searchString) => {
@@ -28,13 +29,11 @@ const actions = {
       if (data.data.length > 0) {
         const obj = data.data.shift();
 
-        commit(`storeFetch`, {
-          attributes: obj.attributes,
-          relationships: obj.relationships
-        });
+        commit(`storeFetch`, obj);
         commit(`storeIncluded`, data.included);
       } else {
-        commit("clearState");
+        console.log("doin nuthin in fetchByMolfile");
+        // commit("clearState");
       }
     });
   }

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -87,10 +87,10 @@ describe("The substance page", () => {
       .eq(3)
       .click();
     // Add CycloHexane to the canvas
-//    cy.get("iframe[id=ketcher]")
-//      .its("0.contentDocument.body")
-//      .find("canvas#canvas")
-//      .click();
+    //    cy.get("iframe[id=ketcher]")
+    //      .its("0.contentDocument.body")
+    //      .find("canvas#canvas")
+    //      .click();
 
     cy.get("iframe[id=ketcher]")
       .its("0.contentDocument.body")
@@ -98,7 +98,7 @@ describe("The substance page", () => {
       .then(cy.wrap)
       .find("#canvas")
       // create first node
-      .click()
+      .click();
     // Save
     cy.get("button:contains('Save Defined Compound')")
       .should("not.be.disabled")
@@ -114,11 +114,11 @@ describe("The substance page", () => {
         new RegExp(
           [
             "",
-            /  Ketcher.*1.00000     0.00000     0/,
+            / {2}Ketcher.*1.00000 {5}0.00000 {5}0/,
             "",
-            /  1  0  0     0  0            999 V2000/,
-            /    6.5000  -13.4000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0/,
-            /M  END/,
+            / {2}1 {2}0 {2}0 {5}0 {2}0 {12}999 V2000/,
+            / {4}6.5000 {2}-13.4000 {4}0.0000 O {3}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0 {2}0/,
+            /M {2}END/,
             ""
           ]
             .map(r => {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -61,6 +61,79 @@ describe("The substance page", () => {
       .find("text")
       .should("exist");
   });
+  it("should post not-loaded defined compounds", () => {
+    // Watch for patches
+    cy.route({
+      method: "POST",
+      url: "/definedCompounds",
+      status: 201,
+      response: {}
+    }).as("post");
+
+    // Select ill defined compound to access Ketcher
+    cy.get("#compound-type-dropdown").select("Defined Compound");
+
+    // Verify ketcher has loaded
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty");
+    // Click Oxygen Button
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(cy.wrap)
+      .find("#atom")
+      .find("button")
+      .eq(3)
+      .click();
+    // Add CycloHexane to the canvas
+//    cy.get("iframe[id=ketcher]")
+//      .its("0.contentDocument.body")
+//      .find("canvas#canvas")
+//      .click();
+
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(cy.wrap)
+      .find("#canvas")
+      // create first node
+      .click()
+    // Save
+    cy.get("button:contains('Save Defined Compound')")
+      .should("not.be.disabled")
+      .click();
+
+    // Verify patch status and regex for structure
+    cy.get("@post").should("have.property", "status", 201);
+    cy.get("@post")
+      .its("request.body.data.attributes.molfileV3000")
+      // This regex accepts only a CycloHexane structure (metadata is excluded from cml tag)
+      .should(
+        "match",
+        //the string to be matched
+        //"\n  Ketcher 10 120 1312D 1   1.00000     0.00000     0\n\n  1  0  0     0  0            999 V2000\n    7.4750   -5.2250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\nM  END\n"
+        new RegExp(
+          [
+            /<cml.*><MDocument><MChemicalStruct><molecule molID="m1">/,
+            /<atomArray><atom id="a1" elementType="C" x2="-0.020833333333333037" y2="1.53999998768"\/>/,
+            /<atom id="a2" elementType="C" x2="-1.3545666559968" y2="0.76999999384"\/>/,
+            /<atom id="a3" elementType="C" x2="-1.3545666559968" y2="-0.7701866605051737"\/>/,
+            /<atom id="a4" elementType="C" x2="-0.020833333333333037" y2="-1.5399999876800003"\/>/,
+            /<atom id="a5" elementType="C" x2="1.3128999893301336" y2="-0.7701866605051737"\/>/,
+            /<atom id="a6" elementType="C" x2="1.3128999893301336" y2="0.76999999384"\/>/,
+            /<\/atomArray><bondArray><bond id="b1" atomRefs2="a1 a2" order="1"\/>/,
+            /<bond id="b2" atomRefs2="a1 a6" order="1"\/><bond id="b3" atomRefs2="a2 a3" order="1"\/>/,
+            /<bond id="b4" atomRefs2="a3 a4" order="1"\/><bond id="b5" atomRefs2="a4 a5" order="1"\/>/,
+            /<bond id="b6" atomRefs2="a5 a6" order="1"\/><\/bondArray><\/molecule><\/MChemicalStruct><\/MDocument><\/cml>/
+          ]
+            .map(r => {
+              return r.source;
+            })
+            .join("")
+        )
+      );
+  });
   it("should post not-loaded illdefined compounds", () => {
     // Watch for patches
     cy.route({
@@ -89,7 +162,7 @@ describe("The substance page", () => {
       .click();
 
     // Save
-    cy.get("button:contains('Save Compound')")
+    cy.get("button:contains('Save Ill Defined Compound')")
       .should("not.be.disabled")
       .click();
 
@@ -140,7 +213,7 @@ describe("The substance page", () => {
     cy.get("[data-cy=search-button]").click();
 
     // Save
-    cy.get("button:contains('Save Compound')")
+    cy.get("button:contains('Save Ill Defined Compound')")
       .should("not.be.disabled")
       .click();
 

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -108,7 +108,7 @@ describe("The substance page", () => {
     cy.get("@post").should("have.property", "status", 201);
     cy.get("@post")
       .its("request.body.data.attributes.molfileV2000")
-      // This regex accepts only a CycloHexane structure (metadata is excluded from cml tag)
+      // This regex accepts only an Oxygen structure
       .should(
         "match",
         new RegExp(

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -62,7 +62,7 @@ describe("The substance page", () => {
       .should("exist");
   });
   it("should post not-loaded defined compounds", () => {
-    // Watch for patches
+    // Watch for posts
     cy.route({
       method: "POST",
       url: "/definedCompounds",

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -104,7 +104,7 @@ describe("The substance page", () => {
       .should("not.be.disabled")
       .click();
 
-    // Verify patch status and regex for structure
+    // Verify post status and regex for structure
     cy.get("@post").should("have.property", "status", 201);
     cy.get("@post")
       .its("request.body.data.attributes.molfileV2000")

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -107,30 +107,24 @@ describe("The substance page", () => {
     // Verify patch status and regex for structure
     cy.get("@post").should("have.property", "status", 201);
     cy.get("@post")
-      .its("request.body.data.attributes.molfileV3000")
+      .its("request.body.data.attributes.molfileV2000")
       // This regex accepts only a CycloHexane structure (metadata is excluded from cml tag)
       .should(
         "match",
-        //the string to be matched
-        //"\n  Ketcher 10 120 1312D 1   1.00000     0.00000     0\n\n  1  0  0     0  0            999 V2000\n    7.4750   -5.2250    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\nM  END\n"
         new RegExp(
           [
-            /<cml.*><MDocument><MChemicalStruct><molecule molID="m1">/,
-            /<atomArray><atom id="a1" elementType="C" x2="-0.020833333333333037" y2="1.53999998768"\/>/,
-            /<atom id="a2" elementType="C" x2="-1.3545666559968" y2="0.76999999384"\/>/,
-            /<atom id="a3" elementType="C" x2="-1.3545666559968" y2="-0.7701866605051737"\/>/,
-            /<atom id="a4" elementType="C" x2="-0.020833333333333037" y2="-1.5399999876800003"\/>/,
-            /<atom id="a5" elementType="C" x2="1.3128999893301336" y2="-0.7701866605051737"\/>/,
-            /<atom id="a6" elementType="C" x2="1.3128999893301336" y2="0.76999999384"\/>/,
-            /<\/atomArray><bondArray><bond id="b1" atomRefs2="a1 a2" order="1"\/>/,
-            /<bond id="b2" atomRefs2="a1 a6" order="1"\/><bond id="b3" atomRefs2="a2 a3" order="1"\/>/,
-            /<bond id="b4" atomRefs2="a3 a4" order="1"\/><bond id="b5" atomRefs2="a4 a5" order="1"\/>/,
-            /<bond id="b6" atomRefs2="a5 a6" order="1"\/><\/bondArray><\/molecule><\/MChemicalStruct><\/MDocument><\/cml>/
+            "",
+            /  Ketcher.*1.00000     0.00000     0/,
+            "",
+            /  1  0  0     0  0            999 V2000/,
+            /    6.5000  -13.4000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0/,
+            /M  END/,
+            ""
           ]
             .map(r => {
               return r.source;
             })
-            .join("")
+            .join("\n")
         )
       );
   });

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -86,11 +86,6 @@ describe("The substance page", () => {
       .find("button")
       .eq(3)
       .click();
-    // Add CycloHexane to the canvas
-    //    cy.get("iframe[id=ketcher]")
-    //      .its("0.contentDocument.body")
-    //      .find("canvas#canvas")
-    //      .click();
 
     cy.get("iframe[id=ketcher]")
       .its("0.contentDocument.body")


### PR DESCRIPTION
our hands are tied here for the moment to make a PATCH to an existing compound because the ketcher window is currently only delivering a v2000 molfile, check [here for the convo](https://github.com/Chemical-Curation/chemcurator_vuejs/issues/55#issuecomment-700998588), I have used `initial_molfile` as an attribute on the ketcher component to establish what the editor's state is with no changes, this gets updated if a search is done for a compound and will trigger the ability to save, there is also the `blank` attribute that will be static to test if the editor is cleared. They are simply the molfile with the first line trimmed off because there is always a timestamp there. So, part of this functionality is not working until we get ketcher to publish V3000, as is in the conversation linked above @cmgrulke is cool with this for now.
