### PR TITLE
Remove problematic console command

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -29,8 +29,6 @@ export default {
   },
   post: async (context, body) => {
     let resource = await context.dispatch("getResourceURI");
-    if (!resource)
-      console.error("Did you define getResourceURI action on your module?");
 
     return HTTP.post(`/${resource}`, { data: { ...body } });
   }


### PR DESCRIPTION
This repairs the prod build that was failing due to a console command

To test build on staging-release build the environment either from npm:
npm run build
or using the vue ui tool:
build -> Run Task (verify your Parameters are set to production mode)

On staging the output should be:

```
Module Error (from ./node_modules/thread-loader/dist/cjs.js):

/home/michael/Code/chemcurator_vuejs/src/store/actions.js
  33:7  error  Unexpected console statement  no-console
```

This branch resolves those issues by removing these console logs that were there to verify a resource URI was provided on the module's actions.