### PR TITLE
84 substance page anonymous

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -11,6 +11,7 @@
         @click="saveCompound(type)"
         variant="primary"
         :disabled="!editorChanged"
+        v-if="editable"
         >Save Compound</b-button
       >
     </div>
@@ -28,7 +29,8 @@ export default {
     MarvinWindow
   },
   props: {
-    type: String
+    type: String,
+    editable: Boolean
   },
   computed: {
     editorChanged: function() {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -38,7 +38,7 @@
         <b-nav-item-dropdown
           name="user-profile"
           right
-          v-if="username"
+          v-if="isAuthenticated"
           data-cy="user-dropdown"
         >
           <template v-slot:button-content>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -20,7 +20,6 @@
         <b-form-input
           class="mr-2 search"
           v-model="searchString"
-          v-if="username"
           placeholder="Search Compounds (cid or inchikey)"
           data-cy="search-box"
           @keyup.enter="searchCompound"
@@ -29,7 +28,6 @@
           class="mr-2"
           variant="dark"
           @click="searchCompound"
-          v-if="username"
           :disabled="searchString.length == 0"
           data-cy="search-button"
         >

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="mb-5">
     <div class="text-left">
       <h3>Synonyms</h3>
     </div>
@@ -24,11 +24,11 @@
         table-variant="danger"
       ></b-table>
     </div>
-    <div class="d-flex flex-row justify-content-end my-3">
+    <div class="d-flex flex-row justify-content-end my-3" v-if="editable">
       <b-button
         id="synonym-reset-button"
         @click="resetRowData"
-        :disabled="!buttonsEnabled || !isAuthenticated"
+        :disabled="!buttonsEnabled"
         >Reset</b-button
       >
       <b-button
@@ -36,7 +36,7 @@
         class="ml-1"
         variant="primary"
         @click="save"
-        :disabled="!buttonsEnabled || !isAuthenticated"
+        :disabled="!buttonsEnabled"
       >
         Save Synonyms
       </b-button>
@@ -60,7 +60,8 @@ export default {
   },
   props: {
     // Substance ID to which these synonyms will be related
-    substanceId: String
+    substanceId: String,
+    editable: Boolean
   },
   data() {
     return {
@@ -270,9 +271,9 @@ export default {
      * work well here.
      */
     save: async function() {
-      if (!this.isAuthenticated) {
+      if (!this.editable) {
         this.alert({
-          message: "Unauthenticated",
+          message: "This table cannot be edited",
           color: "warning",
           dismissCountDown: 15
         });
@@ -430,7 +431,7 @@ export default {
     // Load grid styling
     this.defaultColDef = {
       flex: 1,
-      editable: this.isAuthenticated,
+      editable: this.editable,
       resizable: true,
       sortable: true
     };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -15,9 +15,6 @@ const routes = [
     path: "/substance",
     name: "substance",
     component: () => import("../views/Substance"),
-    meta: {
-      requiresAuth: true
-    }
   },
   {
     path: "/vocabularies",

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -51,6 +51,7 @@ const router = new VueRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
+  // validate and wait for every navigation.  This should probably be done in the background
   await store.dispatch("auth/fetchUser");
   if (to.meta.requiresAuth) {
     if (to.meta.requiresSuperuser && !store.getters["auth/isSuperuser"]) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import VueRouter from "vue-router";
 import store from "@/store";
 import Home from "@/views/Home.vue";
+import auth from "@/store/modules/auth";
 
 Vue.use(VueRouter);
 
@@ -50,8 +51,8 @@ const router = new VueRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
+  await store.dispatch("auth/fetchUser");
   if (to.meta.requiresAuth) {
-    await store.dispatch("auth/fetchUser");
     if (to.meta.requiresSuperuser && !store.getters["auth/isSuperuser"]) {
       next({
         name: "unauthorized"
@@ -59,6 +60,17 @@ router.beforeEach(async (to, from, next) => {
       return;
     }
     if (!store.getters["auth/isAuthenticated"]) {
+      const username = auth.state.username;
+      const alert = {
+        message: !username
+          ? "Please log in..."
+          : `${username}, you are no longer logged in!`,
+        color: !username ? "success" : "danger",
+        dismissCountDown: 4
+      };
+      store.dispatch("alert/alert", alert, {
+        root: true
+      });
       next({
         name: "home"
       });

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -14,7 +14,7 @@ const routes = [
   {
     path: "/substance",
     name: "substance",
-    component: () => import("../views/Substance"),
+    component: () => import("../views/Substance")
   },
   {
     path: "/vocabularies",

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -6,36 +6,26 @@ const state = {
   firstName: "",
   lastName: "",
   username: "",
-  is_superuser: ""
+  is_superuser: "",
+  authenticated: false
 };
 
 // getters
 const getters = {
-  isAuthenticated: state => !(state.username === ""),
+  isAuthenticated: state => state.authenticated,
   isSuperuser: state => state.is_superuser === true
 };
 
 // actions
 const actions = {
-  fetchUser: async ({ commit, dispatch }) => {
+  fetchUser: async ({ commit }) => {
     await HTTP.get("/login/")
-      .then(response => commit("setUser", response.data))
+      .then(response => {
+        commit("setUser", response.data);
+        commit("authenticate", true);
+      })
       .catch(() => {
-        const b = state.username.length === 0;
-        const alert = {
-          message: b
-            ? "Please log in..."
-            : `${state.username}, you are no longer logged in!`,
-          color: b ? "success" : "danger",
-          dismissCountDown: 4
-        };
-        commit("setUser", {});
-        router.push({
-          name: "home"
-        });
-        dispatch("alert/alert", alert, {
-          root: true
-        });
+        commit("authenticate", false);
       });
   },
   login: async ({ commit }, { username, password }) => {
@@ -50,6 +40,7 @@ const actions = {
       }
     );
     commit("setUser", response.data);
+    commit("authenticate", true);
     router.push("/").catch(() => {});
   },
   logout: async ({ commit, dispatch }) => {
@@ -61,6 +52,7 @@ const actions = {
     await HTTP.delete("/login/")
       .then(() => {
         commit("setUser", {});
+        commit("authenticate", false);
         router
           .push({
             name: "home"
@@ -72,6 +64,7 @@ const actions = {
       })
       .catch(() => {
         commit("setUser", {});
+        commit("authenticate", false);
         router
           .push({
             name: "home"
@@ -92,6 +85,9 @@ const mutations = {
     state.lastName = user.last_name || "";
     state.username = user.username || "";
     state.is_superuser = user.is_superuser || "";
+  },
+  authenticate(state, authenticated) {
+    state.authenticated = authenticated;
   }
 };
 

--- a/src/store/modules/compound.js
+++ b/src/store/modules/compound.js
@@ -29,7 +29,6 @@ let actions = {
       await router.push("substance");
     dispatch("clearAllStates");
 
-    dispatch("auth/fetchUser", null, { root: true });
     const endpoint =
       searchString.indexOf("-") > 0
         ? "/definedCompounds?include=substance&filter[inchikey]="

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,8 +2,7 @@
   <b-row class="about text-center">
     <b-col cols="3">
       <HelloWorld msg="Welcome to ChemReg" />
-      <p v-if="username"></p>
-      <LoginCard v-else />
+      <LoginCard v-if="!isAuthenticated" class="mx-auto" />
     </b-col>
     <b-col>
       <p class="lead text-justify">{{ aboutBlurb }}</p>

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -29,10 +29,14 @@
             />
           </b-form-group>
         </div>
-        <ChemicalEditors v-show="type !== 'none'" :type="type" />
+        <ChemicalEditors
+          v-show="type !== 'none'"
+          :type="type"
+          :editable="isAuthenticated"
+        />
       </b-col>
     </b-row>
-    <SynonymTable :substance-id="substanceId" />
+    <SynonymTable :substance-id="substanceId" :editable="isAuthenticated" />
     <SubstanceRelationshipTable class="mb-5" :substance-id="substanceId" />
     <ListTable class="mb-5" :substance-id="substanceId" />
   </b-container>
@@ -44,7 +48,7 @@ import SubstanceForm from "@/components/substance/SubstanceForm";
 import SynonymTable from "@/components/synonyms/agSynonymTable";
 import SubstanceRelationshipTable from "@/components/substance/agSubstanceRelationshipTable";
 import ListTable from "@/components/records/agRecordTable";
-import { mapState } from "vuex";
+import { mapGetters, mapState } from "vuex";
 
 export default {
   name: "home",
@@ -54,6 +58,7 @@ export default {
     };
   },
   computed: {
+    ...mapGetters("auth", ["isAuthenticated"]),
     ...mapState("compound", { compoundType: "type" }),
     ...mapState("compound/definedcompound", { definedCompoundData: "data" }),
     ...mapState("compound/illdefinedcompound", {

--- a/tests/e2e/specs/home.js
+++ b/tests/e2e/specs/home.js
@@ -8,9 +8,6 @@ describe("The home page as seen by a visitor", () => {
   it("should display the login form to a non-authenticated user", () => {
     cy.get("#login-card");
   });
-  it("should not display the search bar form to a non-authenticated user", () => {
-    cy.get("[data-cy=search-box]").should("not.exist");
-  });
   it("refuses bad logins", function() {
     cy.get("input[name=username]").type("foo");
     cy.get("input[name=password]").type("bar{enter}");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -17,25 +17,47 @@ let qstResponse = {
   ]
 };
 
-describe("The substance page", () => {
+describe.only("The substance page anonymous access", () => {
   beforeEach(() => {
-    cy.adminLogin();
     cy.server();
     cy.route("/queryStructureTypes*", qstResponse);
     cy.visit("/substance");
   });
+
   it("should have dropdown", () => {
     cy.get("#compound-type-dropdown").contains("None");
     cy.get("#compound-type-dropdown").contains("Defined Compound");
     cy.get("#compound-type-dropdown").contains("Ill Defined");
     cy.get("#compound-type-dropdown").contains("Markush");
   });
+
   it("should toggle ketcher/marvinjs on dropdown", () => {
     cy.get("#compound-type-dropdown").select("Defined Compound");
     cy.get("iframe[id=ketcher]");
     cy.get("#compound-type-dropdown").select("Ill Defined");
     cy.get("iframe[id=marvin]");
   });
+
+  it("should load the substance form", () => {
+    // Search
+    cy.get("[data-cy=search-box]").type("DTXCID302000003");
+    cy.get("[data-cy=search-button]").click();
+
+    cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
+    cy.get("#substanceID").should("have.value", "DTXSID502000000");
+    cy.get("#preferredName").should("have.value", "Sample Substance");
+    cy.get("#casrn").should("have.value", "1234567-89-5");
+    cy.get("#qcLevel").should("have.value", "1");
+    cy.get("#source").should("have.value", "1");
+    cy.get("#substanceType").should("have.value", "1");
+    cy.get("#substanceDescription").should(
+      "have.value",
+      "This is the description for the test substance"
+    );
+    cy.get("#privateQCNotes").should("have.value", "Private QC notes");
+    cy.get("#publicQCNotes").should("have.value", "Public QC notes");
+  });
+
   it("should load defined compound into ketcher window", () => {
     // Verify no elements are in the iframe
     cy.get("iframe[id=ketcher]")
@@ -67,6 +89,18 @@ describe("The substance page", () => {
       .should("contain", "O=C(CCCN1CCC(C2C=CC(C)=CC=2)(O)CC1)C1C=CC(F)=CC=1")
       .should("contain", "AGAHNABIDCTLHW-UHFFFAOYSA-N");
   });
+});
+
+describe("The substance page authenticated access", () => {
+  beforeEach(() => {
+    cy.adminLogin();
+  });
+  beforeEach(() => {
+    cy.server();
+    cy.route("/queryStructureTypes*", qstResponse);
+    cy.visit("/substance");
+  });
+
   it("should post not-loaded defined compounds", () => {
     // Watch for posts
     cy.route({
@@ -121,7 +155,7 @@ describe("The substance page", () => {
             /M {2}V30 BEGIN CTAB/,
             /M {2}V30 COUNTS 1 0 0 0 0/,
             /M {2}V30 BEGIN ATOM/,
-            /M {2}V30 1 O 6.5000 -15.05 0.0000 0/,
+            /M {2}V30 1 O [0-9]+\.[0-9]+ -*[0-9]+\.[0-9]+ 0.0000 0/,  // numeric wildcards for position
             /M {2}V30 END ATOM/,
             /M {2}V30 BEGIN BOND/,
             /M {2}V30 END BOND/,
@@ -135,6 +169,7 @@ describe("The substance page", () => {
         )
       );
   });
+
   it("should post not-loaded illdefined compounds", () => {
     // Watch for patches
     cy.route({
@@ -195,6 +230,7 @@ describe("The substance page", () => {
         )
       );
   });
+
   it("should patch loaded illdefined compounds", () => {
     // Watch for patches
     cy.route({
@@ -236,6 +272,7 @@ describe("The substance page", () => {
       // Verifying the exact structure would make this test brittle
       .should("match", /(<cml).*(><MDocument>).+(<\/MDocument><\/cml>)/);
   });
+
   it("should fetch from server when ketcher changes", () => {
     cy.get("#compound-type-dropdown").select("Defined Compound");
     cy.get("iframe[id=ketcher]")
@@ -281,30 +318,13 @@ describe("The substance page", () => {
     // Check substance loaded
     cy.get("#substanceID").should("have.value", "DTXSID202000002");
   });
-  it("should load the substance form", () => {
-    // Search
-    cy.get("[data-cy=search-box]").type("DTXCID302000003");
-    cy.get("[data-cy=search-button]").click();
 
-    cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
-    cy.get("#substanceID").should("have.value", "DTXSID502000000");
-    cy.get("#preferredName").should("have.value", "Sample Substance");
-    cy.get("#casrn").should("have.value", "1234567-89-5");
-    cy.get("#qcLevel").should("have.value", "1");
-    cy.get("#source").should("have.value", "1");
-    cy.get("#substanceType").should("have.value", "1");
-    cy.get("#substanceDescription").should(
-      "have.value",
-      "This is the description for the test substance"
-    );
-    cy.get("#privateQCNotes").should("have.value", "Private QC notes");
-    cy.get("#publicQCNotes").should("have.value", "Public QC notes");
-  });
   it("bad search should alert invalidity", () => {
     cy.get("[data-cy=search-box]").type("compound 47");
     cy.get("[data-cy=search-button]").click();
     cy.get("[data-cy=alert-box]").should("contain", "compound 47 not valid");
   });
+
   it("confirm navigation away from editor changes", () => {
     cy.get("iframe[id=marvin]")
       .its("0.contentDocument.body")
@@ -338,6 +358,7 @@ describe("The substance page", () => {
     cy.get("button:contains('YES')").click();
     cy.url().should("contain", "/lists");
   });
+
   it("logout should provide message to user", () => {
     cy.get("[data-cy=user-dropdown]").click();
     cy.get("[data-cy=logout-button]").click();


### PR DESCRIPTION
closes #84 

This ticket required 2 major changes.

First was removing save buttons and edibility on the substance page components and removing the isAuthenticated check when navigating to the substance page.

Second was a bug with how our system populates the authenticated user.  There is a bug where navigating to a page via url doesn't fetch your user when the page doesn't require authentication locked down.  Steps to replicate on **staging-release** are:

1. Log in at `/`
2. Type in `/substance` in the url bar and hit enter
3. Verify in the top right corner the username has not loaded.

To get around this we have to authenticate the user before every navigation (which is a bit costly and probably needs to be rethought).  This method is valid for MVP though.