### PR TITLE
Update the default 'standard' marvin toolbar to be a 'reporting' toolbar

### DIFF
--- a/marvin/editorws.html
+++ b/marvin/editorws.html
@@ -42,6 +42,7 @@
         if (marvin.Sketch.isSupported()) {
           marvin.sketcherInstance = new marvin.Sketch("sketch");
           marvin.sketcherInstance.setServices(getDefaultServices());
+          marvin.sketcherInstance.setDisplaySettings({toolbars: "reporting"})
           marvin.sketcherInstance.on('molchange', () => exportStructure())
           parent.postMessage("marvinLoaded", "*");
         } else {


### PR DESCRIPTION
closes #95 

Simply needed to add a line specifying `setDisplaySettings({toolbars: "reporting"})`.  I'm not planning on testing this as this is a simple configuration change and shouldn't effect any functionality outside of Marvin.

We could also allow for all visual settings to be controlled through the .env using [setDisplaySettings(JavaScriptObject)](https://marvinjs-demo.chemaxon.com/latest/jsdoc.html#marvin.Sketch.setDisplaySettings(JavaScriptObject))

Rebuild instructions on the [wiki](https://github.com/Chemical-Curation/chemcurator_vuejs/wiki/Marvin-JS)