### PR TITLE
#103 remove loadDetail from fetchByMolfile

### DIFF
--- a/src/store/modules/defined-compound.js
+++ b/src/store/modules/defined-compound.js
@@ -27,7 +27,6 @@ const actions = {
       .then(response => {
         commit(`storeIncluded`, response.data.included);
         let obj = response.data.data.shift();
-        let inc = response.data?.included;
 
         // TODO: The following action is because of the difference in what is returned
         //       by the list and detail serializers.  If the compound is a defined compound
@@ -36,7 +35,6 @@ const actions = {
         //       or if the json:api id is the same as the cid being passed in.
         if (obj) {
           dispatch("getFetch", obj.id);
-          if (inc) commit("substance/loadDetail", inc.shift(), { root: true });
         }
       })
       .catch(err => {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -245,8 +245,8 @@ describe("The substance page anonymous access", () => {
     // Check compound loaded
     cy.get("#recordCompoundID").should("have.value", "DTXCID502000024");
 
-    // Check substance loaded
-    cy.get("#id").should("have.value", "DTXSID202000002");
+    // Check substance not loaded
+    cy.get("#id").should("have.value", "");
   });
 
   it("should load substances without compounds", () => {


### PR DESCRIPTION
this is as simple as it can get, we don't want to load the substance when using `fetchByMolfile`