### PR TITLE
252 name field pk for controlled vocab (Vue)

### DIFF
--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -72,7 +72,6 @@ export default {
     ...mapState("compound/illdefinedcompound", {
       illDefinedCompoundData: "data"
     }),
-    ...mapState("queryStructureType", { qstList: "list" }),
 
     cid: function() {
       if (this.type === "definedCompound") return this.definedCompoundData.id;

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -118,7 +118,7 @@ describe("The substance page anonymous access", () => {
 
     cy.get("#compound-type-dropdown").should("contain", "Deprecated");
     cy.get("#compound-type-dropdown")
-      .find("[value=4]")
+      .find("[value=deprecated]")
       .should("be.selected")
       .should("have.attr", "disabled");
   });
@@ -139,9 +139,9 @@ describe("The substance page anonymous access", () => {
     cy.get("#id").should("have.value", "DTXSID502000000");
     cy.get("#preferredName").should("have.value", "Sample Substance");
     cy.get("#casrn").should("have.value", "1234567-89-5");
-    cy.get("#qcLevel").should("have.value", "1");
-    cy.get("#source").should("have.value", "1");
-    cy.get("#substanceType").should("have.value", "1");
+    cy.get("#qcLevel").should("have.value", "qc-level-1");
+    cy.get("#source").should("have.value", "source-1");
+    cy.get("#substanceType").should("have.value", "substance-type-1");
     cy.get("#description").should(
       "have.value",
       "This is the description for the test substance"
@@ -158,9 +158,9 @@ describe("The substance page anonymous access", () => {
     cy.get("#id").should("have.value", "DTXSID502000000");
     cy.get("#preferredName").should("have.value", "Sample Substance");
     cy.get("#casrn").should("have.value", "1234567-89-5");
-    cy.get("#qcLevel").should("have.value", "1");
-    cy.get("#source").should("have.value", "1");
-    cy.get("#substanceType").should("have.value", "1");
+    cy.get("#qcLevel").should("have.value", "qc-level-1");
+    cy.get("#source").should("have.value", "source-1");
+    cy.get("#substanceType").should("have.value", "substance-type-1");
     cy.get("#description").should(
       "have.value",
       "This is the description for the test substance"
@@ -301,13 +301,13 @@ describe("The substance page authenticated access", () => {
 
     // Build assertion info
     let test_data = [
-      { htmlID: "#qcLevel", name: "Deprecated QC Levels", id: 12 },
+      { htmlID: "#qcLevel", name: "Deprecated QC Levels", id: "deprecated-qc-levels" },
       {
         htmlID: "#source",
         name: "Deprecated Source",
-        id: 9
+        id: "deprecated-source"
       },
-      { htmlID: "#substanceType", name: "Deprecated Substance Type", id: 8 }
+      { htmlID: "#substanceType", name: "Deprecated Substance Type", id: "deprecated-substance-type" }
     ];
 
     // Test Dropdowns

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -3,21 +3,21 @@ import valid_casrns from "../../valid_casrns.js";
 let qstResponse = {
   data: [
     {
-      id: "1",
+      id: "markush-query",
       type: "queryStructureType",
       attributes: {
-        label: "Markush"
+        label: "Markush-Query"
       }
     },
     {
-      id: "2",
+      id: "ill-defined",
       type: "queryStructureType",
       attributes: {
         label: "Ill Defined"
       }
     },
     {
-      id: "4",
+      id: "deprecated",
       type: "queryStructureType",
       attributes: {
         name: "deprecated",


### PR DESCRIPTION
Paired with django/ 252 name field pk for controlled vocab #279 PR 

https://github.com/Chemical-Curation/chemcurator_django/issues/279

Closes #252

Revisions to effected tests and seed data