### PR TITLE
99 add synonym

### DIFF
--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -35,6 +35,7 @@
         id="synonym-add-button"
         class="ml-1"
         variant="success"
+        :disabled="!substanceId"
         @click="addSynonym"
       >
         Add Synonym
@@ -241,6 +242,7 @@ export default {
      * (the synonym store should never be updated by this table)
      */
     resetRowData: function() {
+      this.buttonsEnabled = false
       this.rowData = _.cloneDeep(this.list);
       this.gridOptions.api.refreshCells({
         force: true,
@@ -254,6 +256,17 @@ export default {
      *
      */
     addSynonym: function() {
+      if (!this.substanceId){
+        this.alert({
+          message: "Please load a substance",
+          color: "warning",
+          dismissCountDown: 15
+        });
+        window.scrollTo(0, 0);
+        return;
+      }
+
+      this.buttonsEnabled = true
       if (!this.rowData)
         this.rowData = []
       this.rowData.push({

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -32,6 +32,14 @@
         >Reset</b-button
       >
       <b-button
+        id="synonym-add-button"
+        class="ml-1"
+        variant="success"
+        @click="addSynonym"
+      >
+        Add Synonym
+      </b-button>
+      <b-button
         id="synonym-save-button"
         class="ml-1"
         variant="primary"
@@ -139,6 +147,10 @@ export default {
         // background danger any rows where the id is within the errorRows object
         "bg-danger": params => {
           return this.errorRows.hasOwnProperty(params.data.id);
+        },
+        // background info any rows where there is no id
+        "new-ag-row": params => {
+          return !params.data.id;
         }
       };
     },
@@ -234,6 +246,48 @@ export default {
         force: true,
         suppressFlash: false
       });
+    },
+
+
+    /**
+     * Adds a synonym.
+     *
+     */
+    addSynonym: function() {
+      if (!this.rowData)
+        this.rowData = []
+      this.rowData.push({
+        attributes:{
+          identifier: "",
+          qcNotes: "",
+        },
+        relationships: {
+          source: {
+            data: {
+              type: "source"
+              , id: 0
+            }
+          },
+          synonymQuality: {
+            data: {
+              type: "synonymQuality"
+              , id: 0
+            }
+          },
+          synonymType: {
+            data: {
+              type: "synonymType"
+              , id: 0
+            }
+          },
+          substance: {
+            data: {
+              type: "substance"
+              , id: this.substanceId
+            }
+          },
+        }
+      })
     },
 
     /**
@@ -428,4 +482,8 @@ export default {
 };
 </script>
 
-<style scoped></style>
+<style>
+.ag-row.new-ag-row {
+  background-color: #def2ff !important;
+}
+</style>

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -35,7 +35,7 @@
         id="synonym-add-button"
         class="ml-1"
         variant="success"
-        :disabled="!substanceId"
+        :disabled="!substanceId || loading"
         @click="addSynonym"
       >
         Add Synonym

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -5,7 +5,7 @@ import router from "@/router";
 
 const defaultDetail = () => {
   return {
-    id: null,
+    id: "",
     type: "",
     attributes: {
       preferredName: null,

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -79,7 +79,7 @@ export default {
       if (this.type === "definedCompound") return this.definedCompoundData.id;
       else if (this.type === "none") return "";
       return this.illDefinedCompoundData.id;
-    },
+    }
   },
   watch: {
     compoundType: function() {

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -42,9 +42,9 @@
         />
       </b-col>
     </b-row>
-    <SynonymTable :substance-id="substanceId" :editable="isAuthenticated" />
-    <SubstanceRelationshipTable class="mb-5" :substance-id="substanceId" />
-    <ListTable class="mb-5" :substance-id="substanceId" />
+    <SynonymTable :substance-id="substance.id" :editable="isAuthenticated" />
+    <SubstanceRelationshipTable class="mb-5" :substance-id="substance.id" />
+    <ListTable class="mb-5" :substance-id="substance.id" />
   </b-container>
 </template>
 
@@ -67,6 +67,7 @@ export default {
   computed: {
     ...mapGetters("auth", ["isAuthenticated"]),
     ...mapGetters("queryStructureType", { options: "getOptions" }),
+    ...mapState("substance", { substance: "detail" }),
     ...mapState("compound", { compoundType: "type" }),
     ...mapState("compound/definedcompound", { definedCompoundData: "data" }),
     ...mapState("compound/illdefinedcompound", {
@@ -79,16 +80,6 @@ export default {
       else if (this.type === "none") return "";
       return this.illDefinedCompoundData.id;
     },
-    substanceId: function() {
-      if (
-        this.type === "definedCompound" &&
-        this.definedCompoundData.relationships?.substance
-      )
-        return this.definedCompoundData.relationships?.substance?.data?.id;
-      else if (this.illDefinedCompoundData.relationships?.substance)
-        return this.illDefinedCompoundData.relationships?.substance?.data?.id;
-      return "";
-    }
   },
   watch: {
     compoundType: function() {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -301,13 +301,21 @@ describe("The substance page authenticated access", () => {
 
     // Build assertion info
     let test_data = [
-      { htmlID: "#qcLevel", name: "Deprecated QC Levels", id: "deprecated-qc-levels" },
+      {
+        htmlID: "#qcLevel",
+        name: "Deprecated QC Levels",
+        id: "deprecated-qc-levels"
+      },
       {
         htmlID: "#source",
         name: "Deprecated Source",
         id: "deprecated-source"
       },
-      { htmlID: "#substanceType", name: "Deprecated Substance Type", id: "deprecated-substance-type" }
+      {
+        htmlID: "#substanceType",
+        name: "Deprecated Substance Type",
+        id: "deprecated-substance-type"
+      }
     ];
 
     // Test Dropdowns
@@ -579,6 +587,85 @@ describe("The substance page's Synonym Table", () => {
     cy.get("#synonym-save-button").click();
 
     cy.get("body").should("contain.text", "All synonyms saved successfully");
+  });
+
+  it("should allow adding new synonyms", () => {
+    // Queue a simple success message (actual response is not currently used)
+    cy.route({
+      method: "POST",
+      url: "/synonyms",
+      status: 201,
+      response: {} // currently unneeded
+    }).as("post");
+
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    // Click the add button
+    cy.get("#synonym-add-button")
+      .should("be.enabled")
+      .click();
+
+    // Find the newly added row's first cell and type
+    cy.get("#substanceTable")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row].new-ag-row")
+      .first()
+      .within($newRow => {
+        cy.wrap($newRow)
+          .find("div[col-id='data.identifier_1']")
+          .type("Synonym 9");
+        cy.wrap($newRow)
+          .find("div[col-id='data.source_1']")
+          .type("1");
+        cy.wrap($newRow)
+          .find("div[col-id='data.synonymQuality_1']")
+          .type("1");
+        cy.wrap($newRow)
+          .find("div[col-id='data.synonymType_1']")
+          .type("1");
+      });
+
+    // Save the cell edit
+    cy.get("#synonym-save-button").click();
+
+    cy.get("body").should("contain.text", "All synonyms saved successfully");
+
+    cy.get("@post")
+      .its("request.body.data")
+      .should("deep.eq", {
+        type: "synonym",
+        attributes: {
+          identifier: "Synonym 9",
+          qcNotes: ""
+        },
+        relationships: {
+          source: {
+            data: {
+              type: "source",
+              id: "down-indeed-other-4"
+            }
+          },
+          synonymType: {
+            data: {
+              type: "synonymType",
+              id: "capital-performance-4"
+            }
+          },
+          synonymQuality: {
+            data: {
+              type: "synonymQuality",
+              id: "area-professor-fromage"
+            }
+          },
+          substance: {
+            data: {
+              type: "substance",
+              id: "DTXSID602000001"
+            }
+          }
+        }
+      });
   });
 
   it("should not show deprecated data", () => {


### PR DESCRIPTION
closes #99 

Adds a synonym button to add rows.

**Note** 
If Source or Synonym Quality is left blank a generic "this field is required" error pops up without any way of pointing.  This could be decoded from the pointer or the django error message could change.

If Synonym Type is left blank the request 500s out despite this not being a required field due to failed validation.
