### PR TITLE
add cookie generation to login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17291,6 +17291,11 @@
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.5.tgz",
       "integrity": "sha512-0CSftHY0bDTD+4FbYkuFf6+iKDjZ4h2in2YYJDRMk5daZIjrgT9LjFHvP7Rzqy9/s1pij3zDtTSLRUjsPWMwqg=="
     },
+    "vue-cookies": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.7.4.tgz",
+      "integrity": "sha512-mOS5Btr8V9zvAtkmQ7/TfqJIropOx7etDAgBywPCmHjvfJl2gFbH2XgoMghleLoyyMTi5eaJss0mPN7arMoslA=="
+    },
     "vue-eslint-parser": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "register-service-worker": "^1.7.1",
     "vue": "^2.6.10",
     "vue-class-component": "^7.2.5",
+    "vue-cookies": "^1.7.4",
     "vue-property-decorator": "^9.0.0",
     "vue-router": "^3.1.6",
     "vuex": "^3.4.0"

--- a/src/components/LoginCard.vue
+++ b/src/components/LoginCard.vue
@@ -27,6 +27,15 @@
           v-model="form.password"
         />
       </b-input-group>
+      <b-form-group class="pt-3" id="remember-check">
+        <b-form-checkbox
+          v-model="remember"
+          value="true"
+          unchecked-value="false"
+        >
+          Remember me
+        </b-form-checkbox>
+      </b-form-group>
       <b-button block variant="primary" class="my-3" type="submit"
         >Submit</b-button
       >
@@ -43,16 +52,44 @@ export default {
         username: "",
         password: ""
       },
+      remember: false,
       error: ""
     };
   },
+  watch: {
+    remember: function(newValue) {
+      if (newValue === "false") {
+        this.$cookies.remove("username");
+        this.$cookies.remove("password");
+        this.form.username = "";
+        this.form.password = "";
+      }
+    }
+  },
   methods: {
     onSubmit: function() {
-      this.$store.dispatch("auth/login", this.form).catch(error => {
-        this.error = error.response.data.detail;
-        this.form.password = "";
-        this.$refs["password"].focus();
-      });
+      this.$store
+        .dispatch("auth/login", this.form)
+        .then(() => {
+          if (this.remember) {
+            this.$cookies.set("username", this.form.username);
+            this.$cookies.set("password", this.form.password);
+          }
+        })
+        .catch(error => {
+          this.error = error.response.data.detail;
+          this.form.password = "";
+          this.$refs["password"].focus();
+        });
+    }
+  },
+  mounted() {
+    let username = this.$cookies.get("username");
+    let password = this.$cookies.get("password");
+    if (username && password) {
+      this.form.username = username;
+      this.form.password = password;
+      this.remember = true;
     }
   }
 };

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,13 @@ import {
 } from "bootstrap-vue/dist/bootstrap-vue.esm";
 import "bootstrap/dist/css/bootstrap.css";
 import "bootstrap-vue/dist/bootstrap-vue.css";
+import VueCookies from "vue-cookies";
 
 Vue.config.productionTip = false;
 Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
+Vue.use(VueCookies);
+Vue.$cookies.config(process.env.VUE_APP_COOKIE_DURATION);
 
 new Vue({
   router,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -52,6 +52,7 @@ const router = new VueRouter({
 
 router.beforeEach(async (to, from, next) => {
   // validate and wait for every navigation.  This should probably be done in the background
+  sessionStorage.setItem('redirectPath', to.path);
   await store.dispatch("auth/fetchUser");
   if (to.meta.requiresAuth) {
     if (to.meta.requiresSuperuser && !store.getters["auth/isSuperuser"]) {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,5 +1,6 @@
 import router from "@/router";
 import { HTTP } from "../http-common";
+import VueCookies from "vue-cookies";
 
 const state = {
   email: "",
@@ -18,14 +19,24 @@ const getters = {
 
 // actions
 const actions = {
-  fetchUser: async ({ commit }) => {
+  fetchUser: async ({ commit, dispatch }) => {
     await HTTP.get("/login/")
       .then(response => {
         commit("setUser", response.data);
         commit("authenticate", true);
       })
       .catch(() => {
-        commit("authenticate", false);
+        let username = VueCookies.get("username");
+        let password = VueCookies.get("password");
+        if (username && password) {
+          let form = {
+            username: username,
+            password: password
+          };
+          dispatch("login", form);
+        } else {
+          commit("authenticate", false);
+        }
       });
   },
   login: async ({ commit }, { username, password }) => {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -52,7 +52,8 @@ const actions = {
     );
     commit("setUser", response.data);
     commit("authenticate", true);
-    router.push("/").catch(() => {});
+    router.push(sessionStorage.getItem('redirectPath') || "/").catch(() => {});
+    sessionStorage.removeItem('redirectPath');
   },
   logout: async ({ commit, dispatch }) => {
     const alert = {
@@ -64,6 +65,8 @@ const actions = {
       .then(() => {
         commit("setUser", {});
         commit("authenticate", false);
+        VueCookies.remove("username");
+        VueCookies.remove("password");
         router
           .push({
             name: "home"

--- a/template.env
+++ b/template.env
@@ -1,6 +1,8 @@
 VUE_APP_KETCHER_URL="http://localhost:8002"
 VUE_APP_MARVIN_URL="http://localhost:8047"
 VUE_APP_API_URL="http://localhost:8000"
+# https://www.npmjs.com/package/vue-cookies#set-expire-times--input-string-type
+VUE_APP_COOKIE_DURATION="30d"
 
 VUE_APP_TEST_ADMIN_USER="karyn"
 VUE_APP_TEST_ADMIN_PASS="specialP@55word"

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -301,13 +301,21 @@ describe("The substance page authenticated access", () => {
 
     // Build assertion info
     let test_data = [
-      { htmlID: "#qcLevel", name: "Deprecated QC Levels", id: "deprecated-qc-levels" },
+      {
+        htmlID: "#qcLevel",
+        name: "Deprecated QC Levels",
+        id: "deprecated-qc-levels"
+      },
       {
         htmlID: "#source",
         name: "Deprecated Source",
         id: "deprecated-source"
       },
-      { htmlID: "#substanceType", name: "Deprecated Substance Type", id: "deprecated-substance-type" }
+      {
+        htmlID: "#substanceType",
+        name: "Deprecated Substance Type",
+        id: "deprecated-substance-type"
+      }
     ];
 
     // Test Dropdowns

--- a/tests/unit/home.spec.js
+++ b/tests/unit/home.spec.js
@@ -2,10 +2,12 @@ import Home from "@/views/Home.vue";
 import { createLocalVue, mount } from "@vue/test-utils";
 import BootstrapVue from "bootstrap-vue";
 import Vuex from "vuex";
+import VueCookies from "vue-cookies";
 
 const localVue = createLocalVue();
 localVue.use(BootstrapVue);
 localVue.use(Vuex);
+localVue.use(VueCookies);
 
 // Fake Vuex
 let state = {


### PR DESCRIPTION
this uses a new package `vue-cookies` that sets a cookie for both username and password if the checkbox is checked when logging in. The cookie's validation time will be determined by a new environment variable. I am unable to reproduce exactly what Chris is seeing as when I log in to vue I can open a new tab and not be prompted, so I don't know that this will really work until we see it in production. If the cookies exist after the user has been logged out, they will be used to log the user in again during the `fetchUser`  action in the auth module. There is no way that I can figure to test this, but I used a short `SESSION_COOKIE_AGE` setting in django to have the `sessionid` fail after a few seconds. You can then set the env var `VUE_APP_COOKIE_DURATION` in vuejs to something in seconds to see how they work together. There is another setting in the global config for VueCookies that we may use to enforce it being an `https` root that may be useful, but I don't know how useful it would be.

`https://www.npmjs.com/package/vue-cookies#set-global-config`

We might also think of hashing the password when the cookie is being set with a package like `crypto`, but again, I'm not really a site security professional.