### PR TITLE
Removed comments preventing CID from being verif

### DIFF
--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -160,8 +160,7 @@ describe("The substance page anonymous access", () => {
   it("should load the substance form from tree", () => {
     // Search
     cy.get("#DTXSID502000000").click({ force: true });
-    // below isn't implemented yet
-    // cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
+    cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
     cy.get("#id").should("have.value", "DTXSID502000000");
     cy.get("#preferredName").should("have.value", "Sample Substance");
     cy.get("#displayName").should("have.value", "Display Sample Substance");


### PR DESCRIPTION
Closes #118 

See content of ticket 118 for more info - https://github.com/Chemical-Curation/chemcurator_vuejs/issues/118

This functionality was restored in a recently merged ticket. All necessary functionality/tests previously existed but were commented out as a part of the previous tree ticket. For this ticket I solely removed those comments after speaking with @michael-barbour and confirming that fixing this functionality was an "accidental" positive consequence of his ticket - https://github.com/Chemical-Curation/chemcurator_vuejs/issues/101