### PR TITLE
116 substance link

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -9,6 +9,17 @@
         class="col"
       >
         <b-form-input id="recordCompoundID" :value="cid" disabled />
+        <template v-if="showSubstanceLink">
+          <router-link
+            id="substanceLink"
+            :to="{ name: 'substance_detail', params: { sid: sid } }"
+            target="_blank"
+            title="Open substance associated with this compound in a new tab"
+          >
+            <b-icon icon="link" />
+            {{ sid }}
+          </router-link>
+        </template>
       </b-form-group>
       <b-form-group
         label="Structure Type:"
@@ -77,7 +88,7 @@
 import KetcherWindow from "@/components/KetcherWindow";
 import MarvinWindow from "@/components/MarvinWindow";
 import compoundApi from "@/api/compound";
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 
 export default {
   name: "ChemicalEditors",
@@ -119,6 +130,7 @@ export default {
   },
   computed: {
     ...mapGetters("queryStructureType", { options: "getOptions" }),
+    ...mapState("substance", { substance: "detail" }),
 
     initialMolfile: function() {
       return this.initialCompound?.attributes?.molfileV3000 ?? "";
@@ -143,11 +155,24 @@ export default {
         ? this.definedCompound?.id
         : this.illDefinedCompound?.id;
     },
+    sid: function() {
+      // the sid that the loaded compound is related to
+      if (this.cid) {
+        return this.type === "definedCompound"
+          ? this.definedCompound?.relationships?.substance.data.id
+          : this.illDefinedCompound?.relationships.substance.data.id;
+      } else {
+        return null;
+      }
+    },
     editorChanged: function() {
       return (
         (this.marvinChanged && this.type !== "definedCompound") ||
         (this.ketcherChanged && this.type === "definedCompound")
       );
+    },
+    showSubstanceLink: function() {
+      return this.sid !== null && this.sid !== this.substance.id;
     }
   },
   methods: {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -88,7 +88,7 @@
 import KetcherWindow from "@/components/KetcherWindow";
 import MarvinWindow from "@/components/MarvinWindow";
 import compoundApi from "@/api/compound";
-import { mapGetters, mapState } from "vuex";
+import { mapGetters } from "vuex";
 
 export default {
   name: "ChemicalEditors",
@@ -98,7 +98,8 @@ export default {
   },
   props: {
     initialCompound: Object,
-    editable: Boolean
+    editable: Boolean,
+    substance: Object
   },
   data() {
     return {
@@ -130,7 +131,6 @@ export default {
   },
   computed: {
     ...mapGetters("queryStructureType", { options: "getOptions" }),
-    ...mapState("substance", { substance: "detail" }),
 
     initialMolfile: function() {
       return this.initialCompound?.attributes?.molfileV3000 ?? "";
@@ -172,7 +172,8 @@ export default {
       );
     },
     showSubstanceLink: function() {
-      return this.sid !== null && this.sid !== this.substance.id;
+      console.log("yawp", typeof(this.substance.id));
+      return this.sid !== null && this.substance.id !== "" && this.sid !== this.substance.id;
     }
   },
   methods: {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -172,8 +172,11 @@ export default {
       );
     },
     showSubstanceLink: function() {
-      console.log("yawp", typeof(this.substance.id));
-      return this.sid !== null && this.substance.id !== "" && this.sid !== this.substance.id;
+      return (
+        this.sid !== null &&
+        this.substance.id !== "" &&
+        this.sid !== this.substance.id
+      );
     }
   },
   methods: {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,11 @@ const routes = [
     component: () => import("../views/Substance")
   },
   {
+    path: "/substance/:sid",
+    name: "substance_detail",
+    component: () => import("../views/Substance")
+  },
+  {
     path: "/vocabularies",
     name: "controlled-vocabularies",
     component: () => import("../views/Vocabularies"),

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -9,6 +9,7 @@
         <ChemicalEditors
           :initial-compound="compound"
           :editable="isAuthenticated"
+          :substance="substance"
           @change="changed = $event"
         />
       </b-col>
@@ -44,7 +45,7 @@ export default {
   },
   watch: {
     substance: function() {
-      if (this.substance?.relationships.associatedCompound.data?.id)
+      if (this.substance?.relationships?.associatedCompound?.data?.id)
         this.fetchCompound(
           this.substance?.relationships.associatedCompound.data?.id
         );

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -73,6 +73,12 @@ export default {
     window.addEventListener("beforeunload", this.checkChanged);
   },
   mounted() {
+    if (this.$route.params.sid) {
+      this.$store.dispatch("substance/substanceSearch", {
+        searchString: this.$route.params.sid,
+        push: false
+      });
+    }
     this.$store.dispatch("queryStructureType/getList");
     this.$store.dispatch("source/getList");
     this.$store.dispatch("qcLevel/getList");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -158,7 +158,6 @@ describe("The substance page anonymous access", () => {
   });
 
   it("should load the substance form from tree", () => {
-    // Search
     cy.get("#DTXSID502000000").click({ force: true });
     cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
     cy.get("#id").should("have.value", "DTXSID502000000");
@@ -174,6 +173,17 @@ describe("The substance page anonymous access", () => {
     );
     cy.get("#privateQCNote").should("have.value", "Private QC notes");
     cy.get("#publicQCNote").should("have.value", "Public QC notes");
+  });
+
+  it("should show substance link with mismatched DTXCID=>DTXSID", () => {
+    cy.get("#DTXSID502000000").click({ force: true });
+    cy.get("#recordCompoundID").should("have.value", "DTXCID302000003");
+    cy.get("#id").should("have.value", "DTXSID502000000");
+    cy.get("#substanceLink").should("not.exist");
+    cy.get("#DTXSID202000099").click({ force: true });
+    cy.get("#substanceLink")
+      .should("have.attr", "href")
+      .and("include", "DTXSID502000000");
   });
 
   it("should load defined compound into ketcher window", () => {


### PR DESCRIPTION
closes #116 

I've add a router endpoint that will accept the SID as a param
the test shows one way to get the link to show up, but if you load a substance and then edit in Hydrogen Peroxide, OO, you can find it that way too.