### PR TITLE
119 toggle sidebar

### DIFF
--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -1,6 +1,11 @@
 <template>
   <b-container fluid="true" class="mx-5">
-    <SubstanceSidebar />
+    <div 
+      id="sidebar"
+      v-show="ifNoSubstance"
+    >
+      <SubstanceSidebar />
+    </div>
     <b-row>
       <b-col cols="12" order="1" lg="4" order-lg="0">
         <SubstanceForm />
@@ -40,7 +45,10 @@ export default {
   computed: {
     ...mapGetters("auth", ["isAuthenticated"]),
     ...mapState("substance", { substance: "detail" }),
-    ...mapState("queryStructureType", { qstList: "list" })
+    ...mapState("queryStructureType", { qstList: "list" }),
+    ifNoSubstance() {
+      return !this.substance?.id
+    }
   },
   watch: {
     substance: function() {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -855,9 +855,24 @@ describe("The substance page's List Table", () => {
 });
 
 describe("The substance page's Sidebar and Tree View", () => {
+  beforeEach(() => {
+    cy.adminLogin();
+    cy.visit("/substance");
+    cy.server();
+  });
+
   it("should have the sidebar button present", () => {
-    cy.get("button:contains('Toggle Sidebar')")
-      .should("not.be.disabled")
+    cy.get("#sidebar")
+      .should("be.visible")
       .click();
   });
-});
+  
+  it("should not have the sidebar button present", () => {
+    // after loading a substance
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    cy.get("#sidebar").should("not.be.visible");
+  });
+  
+  });


### PR DESCRIPTION
Closes #119 

- When navigating to 'the substance page', if no substance is loaded (via either a Search or previous Substance load), the "Toggle Sidebar" button is visible.
- Once a Substance is loaded, the "Toggle Sidebar" button is not visible.

Added visible/not visible "Toggle Sidebar" test.