### PR TITLE
98 synonym delete

### DIFF
--- a/src/api/base.js
+++ b/src/api/base.js
@@ -25,6 +25,10 @@ class API {
   post(body) {
     return HTTP.post(`/${this.resourceURI}`, { data: { ...body } });
   }
+
+  delete(id) {
+    return HTTP.delete(`/${this.resourceURI}/${id}`);
+  }
 }
 
 export default API;

--- a/src/components/ag-grid/BtnCellRenderer.vue
+++ b/src/components/ag-grid/BtnCellRenderer.vue
@@ -1,32 +1,39 @@
 <template>
-  <span>
-    <b-button
-      size="sm"
-      variant="primary"
-      :disabled="!hasChanged"
-      @click="btnClickedHandler()"
-    >
-      Save
-    </b-button>
-  </span>
+  <b-button
+    size="sm"
+    :variant="params.buttonVariant"
+    :disabled="!isEnabled"
+    @click="btnClickedHandler()"
+  >
+    {{ params.buttonText }}
+  </b-button>
 </template>
 
 <script>
 import Vue from "vue";
-import _ from "lodash";
 
 // Built using https://blog.ag-grid.com/cell-renderers-in-ag-grid-every-different-flavour/ as a guide
 
 export default Vue.extend({
   name: "BtnCellRenderer",
-  computed: {
-    hasChanged: function() {
-      return !_.isEqual(this.params.data.data, this.params.data.initialData);
+  data() {
+    return {
+      isEnabled: false
+    };
+  },
+  watch: {
+    "params.data": {
+      deep: true,
+      immediate: true,
+      handler: "enabled"
     }
   },
   methods: {
     btnClickedHandler() {
-      this.params.clicked(this.params.data);
+      this.params.clicked(this.params);
+    },
+    enabled() {
+      this.isEnabled = this.params.enabled(this.params.data);
     }
   }
 });

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -148,7 +148,7 @@ export default {
         // Add the delete button
         colDefs.push({
           flex: 0,
-          width: 75,
+          width: 85,
           resizable: false,
           sortable: false,
           editable: false,

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -134,10 +134,34 @@ export default {
           sortable: false,
           editable: false,
           headerName: "",
-          type: "rightAligned",
+          cellClass: "p-0 text-center",
           cellRenderer: "btnCellRenderer",
           cellRendererParams: {
-            clicked: this.saveRow
+            clicked: this.saveRow,
+            buttonText: "Save",
+            buttonVariant: "primary",
+            enabled: function(data) {
+              return !_.isEqual(data.data, data.initialData);
+            }
+          }
+        });
+        // Add the delete button
+        colDefs.push({
+          flex: 0,
+          width: 75,
+          resizable: false,
+          sortable: false,
+          editable: false,
+          headerName: "",
+          cellClass: "p-0 text-center",
+          cellRenderer: "btnCellRenderer",
+          cellRendererParams: {
+            clicked: this.deleteRow,
+            buttonText: "Delete",
+            buttonVariant: "danger",
+            enabled: function() {
+              return true;
+            } // delete is always available
           }
         });
       }
@@ -286,14 +310,16 @@ export default {
     buildErrorString: function(error) {
       let readableDetails = error.detail;
 
-      let pointerField = error.source.pointer
-        .split("/")
-        .slice(-1)
-        .shift();
-      if (pointerField !== "nonFieldErrors") {
-        let result = pointerField.replace(/([A-Z])/g, " $1");
-        let finalResult = result.charAt(0).toUpperCase() + result.slice(1);
-        readableDetails = finalResult + ": " + readableDetails;
+      if (error?.source?.pointer) {
+        let pointerField = error.source.pointer
+          .split("/")
+          .slice(-1)
+          .shift();
+        if (pointerField !== "nonFieldErrors") {
+          let result = pointerField.replace(/([A-Z])/g, " $1");
+          let finalResult = result.charAt(0).toUpperCase() + result.slice(1);
+          readableDetails = finalResult + ": " + readableDetails;
+        }
       }
       return readableDetails;
     },
@@ -482,8 +508,28 @@ export default {
             .catch(onFailure);
     },
 
-    saveRow: async function(row) {
-      await this.saveRequest(row);
+    /**
+     * Deletes a single row
+     *
+     * @param row {obj} - rowData object
+     * @returns {Promise} - Deletes a row
+     */
+    deleteRow: function(row) {
+      if (!row.data.created) {
+        SynonymApi.delete(row.data.id)
+          .then(() => {
+            this.gridOptions.rowData.splice(row.rowIndex, 1);
+          })
+          .catch(err => {
+            row.errors = err.response.data.errors;
+          });
+      } else this.gridOptions.rowData.splice(row.rowIndex, 1);
+
+      this.gridOptions.api.redrawRows();
+    },
+
+    saveRow: async function(params) {
+      await this.saveRequest(params.data);
       this.gridOptions.api.redrawRows();
     },
 

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -521,7 +521,7 @@ export default {
             this.gridOptions.rowData.splice(row.rowIndex, 1);
           })
           .catch(err => {
-            row.errors = err.response.data.errors;
+            row.data.errors = err.response.data.errors;
           });
       } else this.gridOptions.rowData.splice(row.rowIndex, 1);
 

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -642,7 +642,7 @@ describe("The substance page's Synonym Table", () => {
       .within(row => {
         // Find the first row's save button, verify disabled
         cy.wrap(row)
-          .last()
+          .eq(5)
           .find("button")
           .should("be.disabled");
 
@@ -653,7 +653,7 @@ describe("The substance page's Synonym Table", () => {
 
         // Save the cell edit
         cy.wrap(row)
-          .last()
+          .eq(5)
           .find("button")
           .should("be.enabled")
           .click();
@@ -662,6 +662,50 @@ describe("The substance page's Synonym Table", () => {
     cy.get("@patch")
       .its("request.body.data.attributes.identifier")
       .should("eq", "Hello World");
+  });
+
+  it("should allow deleting", () => {
+    // Queue a simple success message.  Response is a template, not valid data.
+    cy.route({
+      method: "DELETE",
+      url: /synonyms\/\d+/,
+      status: 204,
+      response: ""
+    });
+
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    // This is the number of rows before delete
+    let rowCount;
+
+    cy.get("#substanceTable")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .its("length")
+      .then($rowCount => {
+        rowCount = $rowCount;
+      });
+
+    // Find the first row's delete button, verify enabled and click
+    cy.get("#substanceTable")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .eq(6)
+      .find("button")
+      .should("be.enabled")
+      .click();
+
+    cy.get("#substanceTable")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .its("length")
+      .should($newRowCount => {
+        // Verify row count after delete is one less than the rows before change
+        expect($newRowCount).to.equal(rowCount - 1);
+      });
   });
 
   it("should allow adding new synonyms", () => {
@@ -703,7 +747,7 @@ describe("The substance page's Synonym Table", () => {
         // Click Save
         cy.wrap($newRow)
           .children()
-          .last()
+          .eq(5)
           .find("button")
           .click();
       });
@@ -814,7 +858,7 @@ describe("The substance page's Synonym Table", () => {
       .find("div.ag-row[role=row]")
       .first()
       .children()
-      .last()
+      .eq(5)
       .find("button")
       .click();
 


### PR DESCRIPTION
closes #98 

~~Needs rebase / merge onto dev when #96 is merged.~~ Done.

Adds a delete button to every row.  The delete button sends a DELETE request and upon a successful delete, removes the row.  If the row fails to delete, the row is left.  If the row is unsaved the row is simply removed.

To test the error handling, the row being deleted should be deleted via the API to force a 404.  The error box should pop up.