### PR TITLE
emit from ChemicalEditors to update compound, test

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -159,7 +159,7 @@ export default {
       // the sid that the loaded compound is related to
       if (this.cid) {
         return this.type === "definedCompound"
-          ? this.definedCompound?.relationships?.substance.data.id
+          ? this.definedCompound?.relationships?.substance?.data?.id
           : this.illDefinedCompound?.relationships.substance.data.id;
       } else {
         return null;
@@ -183,8 +183,10 @@ export default {
     async fetchByMolfile(molfile) {
       if (molfile) {
         let fetchedCompound = await compoundApi.fetchByMolfile(molfile);
-        if (fetchedCompound) this.definedCompound = fetchedCompound;
-        else this.definedCompound = {};
+        if (fetchedCompound) {
+          this.definedCompound = fetchedCompound;
+          this.ketcherChanged = false;
+        } else this.definedCompound = {};
       }
     },
     saveCompound(type) {
@@ -209,21 +211,14 @@ export default {
             id: this.cid,
             body: { ...requestBody, id: this.cid }
           })
-          // Handle the errors
           .catch(err => this.handleError(err));
       } else {
         // If there is no id, save the new compound
         this.$store
           .dispatch("compound/definedcompound/post", requestBody)
           .then(response =>
-            // Load the newly created compound.  We could bypass this action by
-            // storing the response but this verifies the compound is the same and
-            // further searches will work
-            this.$store.dispatch("compound/fetchCompound", {
-              id: response.data.data.id
-            })
+            this.$emit("compoundUpdate", { data: response.data.data })
           )
-          // Handle the errors
           .catch(err => this.handleError(err));
       }
     },
@@ -251,7 +246,6 @@ export default {
             id: compoundId,
             body: { ...requestBody, id: compoundId }
           })
-          // Handle the errors
           .catch(err => this.handleError(err));
       } else {
         // If there is no id, save the new compound
@@ -265,7 +259,6 @@ export default {
               id: response.data.data.id
             })
           )
-          // Handle the errors
           .catch(err => this.handleError(err));
       }
     },

--- a/src/views/Substance.vue
+++ b/src/views/Substance.vue
@@ -13,6 +13,7 @@
           :editable="isAuthenticated"
           :substance="substance"
           @change="changed = $event"
+          @compoundUpdate="fetchCompound($event.data.id)"
         />
       </b-col>
     </b-row>

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -412,6 +412,12 @@ describe("The substance page authenticated access", () => {
             .join("\n")
         )
       );
+    cy.get("#recordCompoundID").should("have.value", "DTXCID902000556");
+    cy.get("#substanceInfoPanel")
+      .should("contain", "18.01528024673462")
+      .should("contain", "O")
+      .should("contain", "H2 O")
+      .should("contain", "XLYOFNOQVPJJNP-UHFFFAOYSA-N");
   });
 
   it("should post not-loaded illdefined compounds", () => {


### PR DESCRIPTION
closes #134 

the `initial_compound` that gets passed from Substance.vue as a prop into ChemicalEditors.vue wasn't being updated after a save in this case. To solve, I emit the response from the post back up to then call the api to get the compound with all of the indigo attributes along with it.

One of the questions that this raises for me is if there is a compound in the editor with a CID and then the user would say add an element to the structure, wouldn't that then be a post to mint a new CID? What would be the case where we would PATCH here? maybe the patch is just ot be used if the structure is the same but reformatted in the editor, i.e. cleaned? not sure about this.

Also, there is a looming bug in a comment in the issue that deals with indigo problems. It is currently possible to save a compound that indigo can't calculate the MolecularWeight from.