### PR TITLE
102 substance show changed

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -185,17 +185,20 @@ export default {
       );
     },
     checkCompound: function() {
-      // if no inital compound, hide feedback until something else is selected
-      if (this.initialCompound.type === undefined) {
-        return this.type !== "none" ? false : true;
-      } else if (this.type === "deprecated") {
-        return this.type !== "deprecated" ? false : true;
-      } else {
-        return this.initialCompound.type !== this.type ||
-          this.initialCompound.id !== this.cid
-          ? false
-          : true;
-      }
+      if (this.substance.id !== "") {
+        // if no inital compound, hide feedback until something else is selected
+        if (this.initialCompound.type === undefined) {
+          return this.type !== "none" ? false : true;
+        } else if (this.type === "deprecated") {
+          return this.type !== "deprecated" ? false : true;
+        } else {
+          // if something is selected, see if it matches
+          return this.initialCompound.type !== this.type ||
+            this.initialCompound.id !== this.cid
+            ? false
+            : true;
+        }
+      } else return true;
     }
   },
   methods: {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -157,9 +157,13 @@ export default {
       return this.definedCompound?.attributes?.inchikey ?? "-";
     },
     cid: function() {
-      return this.type === "definedCompound"
-        ? this.definedCompound?.id
-        : this.illDefinedCompound?.id;
+      if (this.type === "definedCompound") {
+        return this.definedCompound?.id || "";
+      } else if (this.type === "none") {
+        return "";
+      } else {
+        return this.illDefinedCompound?.id || "";
+      }
     },
     sid: function() {
       // the sid that the loaded compound is related to
@@ -185,20 +189,9 @@ export default {
       );
     },
     checkCompound: function() {
-      if (this.substance.id !== "") {
-        // if no inital compound, hide feedback until something else is selected
-        if (this.initialCompound.type === undefined) {
-          return this.type !== "none" ? false : true;
-        } else if (this.type === "deprecated") {
-          return this.type !== "deprecated" ? false : true;
-        } else {
-          // if something is selected, see if it matches
-          return this.initialCompound.type !== this.type ||
-            this.initialCompound.id !== this.cid
-            ? false
-            : true;
-        }
-      } else return true;
+      let sub_id =
+        this.substance.relationships.associatedCompound?.data?.id || "";
+      return sub_id === this.cid;
     }
   },
   methods: {

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -9,9 +9,8 @@
         class="col"
       >
         <b-form-input id="recordCompoundID" :value="cid" disabled />
-        <b-form-invalid-feedback :state="checkCompound">
-          <!-- The Compound below has no relationship to the Substance displayed. -->
-          Compound displayed does not match saved value.
+        <b-form-invalid-feedback id="feedback-cid" :state="checkCompound">
+          This Compound is not related to the Substance displayed.
         </b-form-invalid-feedback>
         <template v-if="showSubstanceLink">
           <router-link
@@ -186,9 +185,11 @@ export default {
       );
     },
     checkCompound: function() {
-      //if no inital compound, hide feedback until something else is selected
+      // if no inital compound, hide feedback until something else is selected
       if (this.initialCompound.type === undefined) {
         return this.type !== "none" ? false : true;
+      } else if (this.type === "deprecated") {
+        return this.type !== "deprecated" ? false : true;
       } else {
         return this.initialCompound.type !== this.type ||
           this.initialCompound.id !== this.cid

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -188,21 +188,12 @@ export default {
     checkCompound: function() {
       //if no inital compound, hide feedback until something else is selected
       if (this.initialCompound.type === undefined) {
-        if (this.type !== "none") {
-          return false;
-        } else {
-          return true;
-        }
+        return this.type !== "none" ? false : true;
       } else {
-        //if there is an inital compound
-        if (
-          this.initialCompound.type !== this.type ||
+        return this.initialCompound.type !== this.type ||
           this.initialCompound.id !== this.cid
-        ) {
-          return false;
-        } else {
-          return true;
-        }
+          ? false
+          : true;
       }
     }
   },

--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -9,6 +9,10 @@
         class="col"
       >
         <b-form-input id="recordCompoundID" :value="cid" disabled />
+        <b-form-invalid-feedback :state="checkCompound">
+          <!-- The Compound below has no relationship to the Substance displayed. -->
+          Compound displayed does not match saved value.
+        </b-form-invalid-feedback>
         <template v-if="showSubstanceLink">
           <router-link
             id="substanceLink"
@@ -180,6 +184,26 @@ export default {
         this.substance.id !== "" &&
         this.sid !== this.substance.id
       );
+    },
+    checkCompound: function() {
+      //if no inital compound, hide feedback until something else is selected
+      if (this.initialCompound.type === undefined) {
+        if (this.type !== "none") {
+          return false;
+        } else {
+          return true;
+        }
+      } else {
+        //if there is an inital compound
+        if (
+          this.initialCompound.type !== this.type ||
+          this.initialCompound.id !== this.cid
+        ) {
+          return false;
+        } else {
+          return true;
+        }
+      }
     }
   },
   methods: {

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -117,7 +117,6 @@ export default {
       return fld === "id" ? true : !this.isAuthenticated;
     },
     markChanged(field) {
-      this.changed++;
       this.checkDataChanges(field);
     },
     clearForm() {
@@ -288,9 +287,11 @@ export default {
     checkDataChanges(field) {
       if (this.form[field] !== this.staticState[field]) {
         this.markUnsavedChanges(field);
+        this.changed++;
       }
       else {
         this.unmarkChanges(field);
+        this.changed--;
       }
     }
   }

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -279,7 +279,11 @@ export default {
     },
     markUnsavedChanges(field) {
       this.$set(this.validationState[field], "state", true);
-      this.$set(this.validationState[field], "message", "This field has unsaved changes.");
+      this.$set(
+        this.validationState[field],
+        "message",
+        "This field has unsaved changes."
+      );
     },
     unmarkChanges(field) {
       this.$set(this.validationState[field], "state", null);
@@ -288,8 +292,7 @@ export default {
       if (this.form[field] !== this.staticState[field]) {
         this.markUnsavedChanges(field);
         this.changed++;
-      }
-      else {
+      } else {
         this.unmarkChanges(field);
         this.changed--;
       }

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -319,8 +319,6 @@ export default {
       this.$set(this.validationState[field], "state", null);
     },
     checkDataChanges(field) {
-      console.log("field", this.form[field]);
-      console.log("static", this.staticState[field]);
       if (this.form[field] !== this.staticState[field]) {
         this.markUnsavedChanges(field);
         this.changed++;

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -119,21 +119,6 @@ export default {
         privateQcNote: attributes.privateQcNote,
         publicQcNote: attributes.publicQcNote
       };
-    },
-    staticState: function() {
-      let { attributes, relationships } = this.substance;
-      return {
-        id: this.substance.id, // sid
-        preferredName: attributes.preferredName || "",
-        displayName: attributes.displayName || "",
-        casrn: attributes.casrn || "",
-        qcLevel: relationships.qcLevel.data.id,
-        source: relationships.source.data.id,
-        substanceType: relationships.substanceType.data.id,
-        description: attributes.description || "",
-        privateQcNote: attributes.privateQcNote || "",
-        publicQcNote: attributes.publicQcNote || ""
-      };
     }
   },
   watch: {
@@ -319,7 +304,11 @@ export default {
       this.$set(this.validationState[field], "state", null);
     },
     checkDataChanges(field) {
-      if (this.form[field] !== this.staticState[field]) {
+      let initialValue;
+      if (this.dropdowns.includes(field)) {
+        initialValue = this.substance.relationships[field].data.id;
+      } else initialValue = this.substance.attributes[field] || "";
+      if (this.form[field] !== initialValue) {
         this.markUnsavedChanges(field);
         this.changed++;
       } else {

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -30,6 +30,11 @@ const defaultDetail = () => {
         data: {
           id: null
         }
+      },
+      associatedCompound: {
+        data: {
+          id: ""
+        }
       }
     }
   };

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -141,7 +141,6 @@ const getters = {
       privateQCNote: detail.attributes.privateQcNote,
       publicQCNote: detail.attributes.publicQcNote
     };
-    
   }
 };
 

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -47,7 +47,6 @@ const defaultState = () => {
 };
 
 const state = defaultState();
-const staticState = () => {};
 
 // actions
 let actions = {
@@ -112,43 +111,11 @@ let actions = {
 };
 
 // getters
-const getters = {
-  form: state => {
-    let { detail } = state;
-    return {
-      id: detail.id, // sid
-      preferredName: detail.attributes.preferredName,
-      displayName: detail.attributes.displayName,
-      casrn: detail.attributes.casrn,
-      qcLevel: detail.relationships.qcLevel.data.id,
-      source: detail.relationships.source.data.id,
-      substanceType: detail.relationships.substanceType.data.id,
-      description: detail.attributes.description,
-      privateQCNote: detail.attributes.privateQcNote,
-      publicQCNote: detail.attributes.publicQcNote
-    };
-  },
-  staticState: staticState => {
-    let { detail } = staticState;
-    return {
-      preferredName: detail.attributes.preferredName,
-      displayName: detail.attributes.displayName,
-      casrn: detail.attributes.casrn,
-      qcLevel: detail.relationships.qcLevel.data.id,
-      source: detail.relationships.source.data.id,
-      substanceType: detail.relationships.substanceType.data.id,
-      description: detail.attributes.description,
-      privateQCNote: detail.attributes.privateQcNote,
-      publicQCNote: detail.attributes.publicQcNote
-    };
-  }
-};
 
 // mutations
 const mutations = {
   ...rootMutations,
   loadDetail(state, payload) {
-    this.staticState = JSON.parse(JSON.stringify(payload));
     state.detail = payload;
   },
   clearForm(state) {
@@ -162,8 +129,7 @@ const mutations = {
 export default {
   namespaced: true,
   state,
-  staticState,
   actions,
-  getters,
+  // getters,
   mutations
 };

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -47,6 +47,7 @@ const defaultState = () => {
 };
 
 const state = defaultState();
+const staticState = () => {};
 
 // actions
 let actions = {
@@ -89,6 +90,7 @@ let actions = {
             color: "warning",
             dismissCountDown: 4
           };
+          // ?: should getting a failed search result clear what you have loaded?
           context.commit("clearState");
           context.dispatch(`compound/clearAllStates`, {}, { root: true });
           context.dispatch("alert/alert", alert, {
@@ -125,6 +127,21 @@ const getters = {
       privateQCNote: detail.attributes.privateQcNote,
       publicQCNote: detail.attributes.publicQcNote
     };
+  },
+  staticState: staticState => {
+    let { detail } = staticState;
+    return {
+      preferredName: detail.attributes.preferredName,
+      displayName: detail.attributes.displayName,
+      casrn: detail.attributes.casrn,
+      qcLevel: detail.relationships.qcLevel.data.id,
+      source: detail.relationships.source.data.id,
+      substanceType: detail.relationships.substanceType.data.id,
+      description: detail.attributes.description,
+      privateQCNote: detail.attributes.privateQcNote,
+      publicQCNote: detail.attributes.publicQcNote
+    };
+    
   }
 };
 
@@ -132,6 +149,7 @@ const getters = {
 const mutations = {
   ...rootMutations,
   loadDetail(state, payload) {
+    this.staticState = JSON.parse(JSON.stringify(payload));
     state.detail = payload;
   },
   clearForm(state) {
@@ -145,6 +163,7 @@ const mutations = {
 export default {
   namespaced: true,
   state,
+  staticState,
   actions,
   getters,
   mutations

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -41,6 +41,10 @@ describe("The substance form", () => {
       "The proposed CASRN does not conform to the regular expression ^[0-9]{2,7}-[0-9]{2}-[0-9]$"
     );
   });
+  it("should show unsaved changes", () => {
+    cy.get("#casrn").type("not a casrn");
+    cy.get("#feedback-casrn").contains("This field has unsaved changes.");
+  });
   it("should validate nonFieldErrors", () => {
     let casrn = valid_casrns[Math.floor(Math.random() * valid_casrns.length)];
     cy.get("#preferredName").type(casrn);

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -105,6 +105,15 @@ describe("The substance form", () => {
       .its("request.body.data.relationships.substanceType.data.id")
       .should("contain", "1");
   });
+  it("should alert on unsaved Compounds", () => {
+    // quark
+    cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
+    cy.get("[data-cy=search-button]").click();
+    cy.get("#compound-type-dropdown").select("Ill defined");
+    cy.get("#feedback-cid").contains(
+      "This Compound is not related to the Substance displayed."
+    );
+  });
 });
 
 describe("The substance page anonymous access", () => {


### PR DESCRIPTION
Closes #102 

**Any unsaved edits to any number of fields on the Substance Form will trigger a notification.
This notification is hidden on save or on reversing changes.**

![102-edit-substance](https://user-images.githubusercontent.com/74921039/103666600-d4b50100-4f42-11eb-90ff-d7ab34ff2cff.png)

**If the currently displayed Compound has no relationship with the currently displayed Substance a notification is triggered.**


![102-small-window](https://user-images.githubusercontent.com/74921039/104482614-1f62f880-5595-11eb-9b52-dd9aea2a06c3.png)


![102-full-window](https://user-images.githubusercontent.com/74921039/104482622-22f67f80-5595-11eb-945b-48cacff1be0a.png)


- Check static data against current Substance data & change validation accordingly
- Check if the currently displayed compound is associated to the substance & change feedback accordingly
- Increment/decrement `changed` for 'save' button activate/deactivate
- e2e test for substance changes & compound match



