### PR TITLE
111 substance relationship updating

### DIFF
--- a/tests/e2e/responses/substance-relationships.json
+++ b/tests/e2e/responses/substance-relationships.json
@@ -40,7 +40,7 @@
           },
           "data": {
             "type": "source",
-            "id": "1"
+            "id": "source-1"
           }
         },
         "relationshipType": {
@@ -50,7 +50,7 @@
           },
           "data": {
             "type": "relationshipType",
-            "id": "1"
+            "id": "area-professor-home"
           }
         }
       },
@@ -92,7 +92,7 @@
           },
           "data": {
             "type": "source",
-            "id": "1"
+            "id": "source-1"
           }
         },
         "relationshipType": {
@@ -102,7 +102,7 @@
           },
           "data": {
             "type": "relationshipType",
-            "id": "1"
+            "id": "area-professor-home"
           }
         }
       },
@@ -144,7 +144,7 @@
           },
           "data": {
             "type": "source",
-            "id": "1"
+            "id": "source-1"
           }
         },
         "relationshipType": {
@@ -154,7 +154,7 @@
           },
           "data": {
             "type": "relationshipType",
-            "id": "1"
+            "id": "area-professor-home"
           }
         }
       },
@@ -184,7 +184,7 @@
           },
           "data": {
             "type": "source",
-            "id": "1"
+            "id": "source-1"
           }
         },
         "substanceType": {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1011,6 +1011,94 @@ describe("The substance page's Relationships Table", () => {
       .should("contain", "DTXSID202000002");
   });
 
+  it("should allow editing (forward and reverse)", () => {
+    // Queue a simple success message.  Response is a template, not valid data.
+    cy.route({
+      method: "PATCH",
+      url: "/substanceRelationships/*",
+      status: 200,
+      response: {} // currently unneeded
+    }).as("patch");
+
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    // Button is disabled
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .eq(4)
+      .find("button")
+      .should("be.disabled");
+
+    // Find the first row's first cell and type (SID cell)
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .first()
+      .type("Hello World\n");
+
+    // Change to forward relationship type.  (Relationship Type cell)
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .find("div[col-id='data.relationshipType']")
+      .dblclick();
+    cy.get("#substance-relationship-table")
+      .find("select")
+      .select("central many throw 3");
+
+    // Save the cell edit
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .eq(4)
+      .find("button")
+      .should("be.enabled")
+      .click();
+
+    // Verify fake sid is in "toSubstance" relationship
+    cy.get("@patch")
+      .its("request.body.data.relationships.toSubstance.data.id")
+      .should("eq", "Hello World");
+
+    // Change to reverse relationship type.  (Relationship Type cell)
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .find("div[col-id='data.relationshipType']")
+      .dblclick();
+    cy.get("#substance-relationship-table")
+      .find("select")
+      .select(
+        "Field paper tree where she. Plant project range research be especially half."
+      );
+
+    // Save the cell edit
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .eq(4)
+      .find("button")
+      .should("be.enabled")
+      .click();
+
+    // Verify fake sid is in "fromSubstance" relationship
+    cy.get("@patch")
+      .its("request.body.data.relationships.fromSubstance.data.id")
+      .should("eq", "Hello World");
+  });
+
   it("should allow adding new substance relationships (forward & reverse)", () => {
     // Queue a simple success message (actual response is not currently used)
     cy.route({

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1039,7 +1039,7 @@ describe("The substance page's Relationships Table", () => {
       .find("div.ag-row[role=row]")
       .first()
       .children()
-      .first()
+      .eq(1)
       .type("Hello World\n");
 
     // Change to forward relationship type.  (Relationship Type cell)


### PR DESCRIPTION
closes #111 

- [x] needs rebasing onto #123 when the PR is merged into dev.  
```
git rebase --onto dev 123-substance-relationship-adding 111-substance-relationship-updating
```

This adds no new code but verifies the updating functionality is complete.  The order these were put into the sprints was backwards so all of the functionality this needed was added in #152.

Adds a test to verify forward and backwards substance relationship editing.