### PR TITLE
124 substance relationship deleting

### DIFF
--- a/src/components/substance/agSubstanceRelationshipTable.vue
+++ b/src/components/substance/agSubstanceRelationshipTable.vue
@@ -322,19 +322,19 @@ export default {
      * @param row {obj} - rowData object
      * @returns {Promise} - Deletes a row
      */
-    // deleteRow: function(row) {
-    //   if (!row.data.created) {
-    //     SubstanceRelationshipApi.delete(row.data.id)
-    //       .then(() => {
-    //         this.gridOptions.rowData.splice(row.rowIndex, 1);
-    //       })
-    //       .catch(err => {
-    //         row.data.errors = err.response.data.errors;
-    //       });
-    //   } else this.gridOptions.rowData.splice(row.rowIndex, 1);
-    //
-    //   this.gridOptions.api.redrawRows();
-    // },
+    deleteRow: function(row) {
+      if (!row.data.created) {
+        SubstanceRelationshipApi.delete(row.data.id)
+          .then(() => {
+            this.gridOptions.rowData.splice(row.rowIndex, 1);
+          })
+          .catch(err => {
+            row.data.errors = err.response.data.errors;
+          });
+      } else this.gridOptions.rowData.splice(row.rowIndex, 1);
+
+      this.gridOptions.api.redrawRows();
+    },
 
     /**
      * Returns a boolean comparing two objects

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1204,7 +1204,6 @@ describe("The substance page's Relationships Table", () => {
       });
   });
 
-
   it("should not show deprecated data", () => {
     // Queue a simple success message (actual response is not currently used)
     cy.route("PATCH", "/synonyms/*", "success");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1160,6 +1160,51 @@ describe("The substance page's Relationships Table", () => {
       });
   });
 
+  it.only("should allow deleting", () => {
+    // Queue a simple success message.  Response is a template, not valid data.
+    cy.route({
+      method: "DELETE",
+      url: /substanceRelationships\/\d+/,
+      status: 204,
+      response: ""
+    });
+
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    // This is the number of rows before delete
+    let rowCount;
+
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .its("length")
+      .then($rowCount => {
+        rowCount = $rowCount;
+      });
+
+    // Find the first row's delete button, verify enabled and click
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .first()
+      .children()
+      .eq(5)
+      .find("button")
+      .should("be.enabled")
+      .click();
+
+    cy.get("#substance-relationship-table")
+      .find("div.ag-center-cols-clipper")
+      .find("div.ag-row[role=row]")
+      .its("length")
+      .should($newRowCount => {
+        // Verify row count after delete is one less than the rows before change
+        expect($newRowCount).to.equal(rowCount - 1);
+      });
+  });
+
+
   it("should not show deprecated data", () => {
     // Queue a simple success message (actual response is not currently used)
     cy.route("PATCH", "/synonyms/*", "success");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1160,7 +1160,7 @@ describe("The substance page's Relationships Table", () => {
       });
   });
 
-  it.only("should allow deleting", () => {
+  it("should allow deleting", () => {
     // Queue a simple success message.  Response is a template, not valid data.
     cy.route({
       method: "DELETE",


### PR DESCRIPTION
close #124 

- [x] needs rebasing onto #123 when the PR is merged into dev.

```git rebase --onto dev 123-substance-relationship-adding 124-substance-relationship-deleting```

Straight forward.  Adds `deleteRow()` function in the same style as `agSynonymTable` and adds a test almost identical to that of the synonym delete test.

This could be abstracted out if we decide to use the `SynonymAPI` and `SubstanceRelationshipAPI` as a mixin variable, but it may be necessary to consider this approach more.  There is a chance abstracting too much away from each of these functions would make further extentions harder.