### PR TITLE
keep form and staticState in component

### DIFF
--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -83,9 +83,7 @@ export default {
     };
   },
   computed: {
-    ...mapState("substance", ["detail"]),
-    ...mapGetters("substance", ["form"]),
-    ...mapGetters("substance", ["staticState"]),
+    ...mapState("substance", { substance: "detail" }),
     ...mapGetters("auth", ["isAuthenticated"]),
     ...mapGetters("qcLevel", { qcLevelOptions: "getOptions" }),
     ...mapGetters("source", { sourceOptions: "getOptions" }),
@@ -97,12 +95,44 @@ export default {
     options: function() {
       return {
         qcLevel: this.qcLevelOptions(
-          this.detail?.relationships.qcLevel.data?.id
+          this.substance?.relationships.qcLevel.data?.id
         ),
-        source: this.sourceOptions(this.detail?.relationships.source.data?.id),
+        source: this.sourceOptions(
+          this.substance?.relationships.source.data?.id
+        ),
         substanceType: this.substanceTypeOptions(
-          this.detail?.relationships.substanceType.data?.id
+          this.substance?.relationships.substanceType.data?.id
         )
+      };
+    },
+    form: function() {
+      let { attributes, relationships } = this.substance;
+      return {
+        id: this.substance.id, // sid
+        preferredName: attributes.preferredName,
+        displayName: attributes.displayName,
+        casrn: attributes.casrn,
+        qcLevel: relationships.qcLevel.data.id,
+        source: relationships.source.data.id,
+        substanceType: relationships.substanceType.data.id,
+        description: attributes.description,
+        privateQCNote: attributes.privateQCNote,
+        publicQCNote: attributes.publicQCNote
+      };
+    },
+    staticState: function() {
+      let { attributes, relationships } = this.substance;
+      return {
+        id: this.substance.id, // sid
+        preferredName: attributes.preferredName || "",
+        displayName: attributes.displayName || "",
+        casrn: attributes.casrn || "",
+        qcLevel: relationships.qcLevel.data.id,
+        source: relationships.source.data.id,
+        substanceType: relationships.substanceType.data.id,
+        description: attributes.description || "",
+        privateQCNote: attributes.privateQCNote || "",
+        publicQCNote: attributes.publicQCNote || ""
       };
     }
   },
@@ -158,7 +188,7 @@ export default {
       )(data);
       // filter out attributes that have not been changed
       if (id) {
-        let { attributes } = this.detail;
+        let { attributes } = this.substance;
         Object.keys(attrs).forEach(key => {
           if (attrs[key] == attributes[key]) delete attrs[key];
         });
@@ -180,7 +210,7 @@ export default {
       )(data);
       // filter out the relationships that haven't been changed
       if (id) {
-        let { relationships } = this.detail;
+        let { relationships } = this.substance;
         Object.keys(related).forEach(key => {
           if (related[key].data.id == relationships[key].data.id)
             delete related[key];

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -289,6 +289,8 @@ export default {
       this.$set(this.validationState[field], "state", null);
     },
     checkDataChanges(field) {
+      console.log("field", this.form[field]);
+      console.log("static", this.staticState[field]);
       if (this.form[field] !== this.staticState[field]) {
         this.markUnsavedChanges(field);
         this.changed++;

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -66,7 +66,7 @@ export default {
     return {
       changed: 0,
       validationState: this.clearValidation(),
-      textareas: ["description", "privateQCNote", "publicQCNote"],
+      textareas: ["description", "privateQcNote", "publicQcNote"],
       dropdowns: ["qcLevel", "source", "substanceType"],
       labels: {
         id: "Substance ID:",
@@ -74,8 +74,8 @@ export default {
         displayName: "Display Name:",
         casrn: "CAS-RN:",
         description: "Substance Description:",
-        privateQCNote: "Private QC Notes:",
-        publicQCNote: "Public QC Notes:",
+        privateQcNote: "Private QC Notes:",
+        publicQcNote: "Public QC Notes:",
         qcLevel: "QC Level:",
         source: "Source:",
         substanceType: "Substance Type:"
@@ -116,8 +116,8 @@ export default {
         source: relationships.source.data.id,
         substanceType: relationships.substanceType.data.id,
         description: attributes.description,
-        privateQCNote: attributes.privateQCNote,
-        publicQCNote: attributes.publicQCNote
+        privateQcNote: attributes.privateQcNote,
+        publicQcNote: attributes.publicQcNote
       };
     },
     staticState: function() {
@@ -131,8 +131,8 @@ export default {
         source: relationships.source.data.id,
         substanceType: relationships.substanceType.data.id,
         description: attributes.description || "",
-        privateQCNote: attributes.privateQCNote || "",
-        publicQCNote: attributes.publicQCNote || ""
+        privateQcNote: attributes.privateQcNote || "",
+        publicQcNote: attributes.publicQcNote || ""
       };
     }
   },
@@ -164,8 +164,8 @@ export default {
         casrn: { ...clean },
         preferredName: { ...clean },
         displayName: { ...clean },
-        privateQCNote: { ...clean },
-        publicQCNote: { ...clean },
+        privateQcNote: { ...clean },
+        publicQcNote: { ...clean },
         qcLevel: { ...clean },
         source: { ...clean },
         description: { ...clean },
@@ -183,8 +183,8 @@ export default {
         "displayName",
         "casrn",
         "description",
-        "publicQCNote",
-        "privateQCNote"
+        "publicQcNote",
+        "privateQcNote"
       )(data);
       // filter out attributes that have not been changed
       if (id) {

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -12,8 +12,8 @@ const defaultDetail = () => {
       displayName: null,
       casrn: null,
       description: null,
-      privateQCNote: null,
-      publicQCNote: null
+      privateQcNote: null,
+      publicQcNote: null
     },
     relationships: {
       source: {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -166,8 +166,8 @@ describe("The substance page anonymous access", () => {
       "have.value",
       "This is the description for the test substance"
     );
-    cy.get("#privateQCNote").should("have.value", "Private QC notes");
-    cy.get("#publicQCNote").should("have.value", "Public QC notes");
+    cy.get("#privateQcNote").should("have.value", "Private QC notes");
+    cy.get("#publicQcNote").should("have.value", "Public QC notes");
   });
 
   it("should load the substance form from tree", () => {
@@ -184,8 +184,8 @@ describe("The substance page anonymous access", () => {
       "have.value",
       "This is the description for the test substance"
     );
-    cy.get("#privateQCNote").should("have.value", "Private QC notes");
-    cy.get("#publicQCNote").should("have.value", "Public QC notes");
+    cy.get("#privateQcNote").should("have.value", "Private QC notes");
+    cy.get("#publicQcNote").should("have.value", "Public QC notes");
   });
 
   it("should show substance link with mismatched DTXCID=>DTXSID", () => {


### PR DESCRIPTION
here's an example of how we could move the staticState into the component, this is a quick and dirty example, but as you can see now we can have a blank form, enter text and then delete it and the changed state will be removed. with the staticState that was coming from the store we were comparing `null` to an empty string `""`. Not to say that it couldn't come from the store, but we need to set up the initial val that is is static state w/ what the form's initial state would be and the input if cleared out would be `""` not `null`.

In the 122/145 tickets that I am working on the substance and compound will be passed in as props to SubstanceForm so this gets us moving in the right direction there too

there may be a better way to in essense duplicate the form in a computed property w/o duplicating all of that code which you may have ideas on?