### PR TITLE
148 reset form

### DIFF
--- a/src/components/ChemicalEditors.vue
+++ b/src/components/ChemicalEditors.vue
@@ -89,6 +89,15 @@
         v-if="editable && type !== 'none'"
         >Save Compound</b-button
       >
+      <b-button
+        id="reset-compound-btn"
+        class="ml-2"
+        @click="resetCompound"
+        variant="secondary"
+        :disabled="!editorChanged"
+        v-if="editable && type !== 'none'"
+        >Reset Compound</b-button
+      >
     </div>
   </div>
 </template>
@@ -197,6 +206,13 @@ export default {
     }
   },
   methods: {
+    resetCompound() {
+      if (this.type === "definedCompound") {
+        this.$refs["ketcher"].resetKetcher();
+      } else {
+        this.$refs["marvin"].resetMarvin();
+      }
+    },
     saveCompound(type) {
       if (type === "definedCompound") {
         this.saveDefinedCompound();

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -39,6 +39,9 @@ export default {
     };
   },
   methods: {
+    resetKetcher: function() {
+      this.loadMolfile(this.loadedMolfile);
+    },
     loadMolfile: function(molfile, loaded) {
       if (molfile) {
         this.ketcherFrame.contentWindow.postMessage(

--- a/src/components/KetcherWindow.vue
+++ b/src/components/KetcherWindow.vue
@@ -40,7 +40,10 @@ export default {
   },
   methods: {
     resetKetcher: function() {
-      this.loadMolfile(this.loadedMolfile);
+      if (this.removeHeader(this.loadedMolfile) === this.blank) {
+        this.clearMolfile();
+      }
+      else this.loadMolfile(this.loadedMolfile);
     },
     loadMolfile: function(molfile, loaded) {
       if (molfile) {

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -32,9 +32,13 @@ export default {
   },
   methods: {
     resetMarvin: function() {
-      // something like ...
-      // this.loadMrvfile(this.localMrvfile);
-      // ? 
+      this.marvinFrame.contentWindow.postMessage(
+        {
+          type: "importMrvfile",
+          mrvfile: this.loadedMrvfile
+        },
+        "*"
+      );
     },
     loadMrvfile: function(mrvfile) {
       this.loadedMrvfile = "";

--- a/src/components/MarvinWindow.vue
+++ b/src/components/MarvinWindow.vue
@@ -31,6 +31,11 @@ export default {
     };
   },
   methods: {
+    resetMarvin: function() {
+      // something like ...
+      // this.loadMrvfile(this.localMrvfile);
+      // ? 
+    },
     loadMrvfile: function(mrvfile) {
       this.loadedMrvfile = "";
       this.marvinFrame.contentWindow.postMessage(

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -185,19 +185,17 @@ export default {
               initialValue = this.substance.attributes[field] || "";
               mapping = "attributes";
               };
-            
-            // if (this.form[field] !== initialValue) {
-              // console.log(this.form[field], ":b:", initialValue);
+            if (this.form[field] !== initialValue) {
               let mix = {mapping,field,initialValue};
               this.$store.commit("substance/resetDetail", mix);
-            // }
+            }
           }}
       );
      
 
       
-      // this.validationState = this.clearValidation();
-      // Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
+      this.validationState = this.clearValidation();
+      Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
     },
     clearValidation() {
       let clean = {

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -152,6 +152,9 @@ export default {
       Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
     }
   },
+  mounted() {
+    this.loadForm(this.substance);
+  },
   methods: {
     loadForm(obj) {
       let { attributes, relationships } = obj;

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -57,7 +57,7 @@
       class="ml-2"
       @click="resetForm"
       variant="secondary"
-      >Reset Form</b-button
+      >Reset Substance</b-button
     >
   </b-form>
 </template>

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -52,7 +52,11 @@
       :disabled="btnDisabled"
       >Save Substance</b-button
     >
-    <b-button class="ml-2" @click="resetForm" variant="secondary"
+    <b-button
+      id="reset-substance-btn"
+      class="ml-2"
+      @click="resetForm"
+      variant="secondary"
       >Reset Form</b-button
     >
   </b-form>
@@ -71,6 +75,7 @@ export default {
   ],
   data() {
     return {
+      form: {},
       formChanged: {
         preferredName: 0,
         displayName: 0,
@@ -138,10 +143,19 @@ export default {
           this.substance?.relationships?.substanceType?.data?.id
         )
       };
-    },
-    form: function() {
-      let { attributes, relationships } = this.substance;
-      return {
+    }
+  },
+  watch: {
+    "substance.id": function() {
+      this.loadForm(this.substance);
+      this.validationState = this.clearValidation();
+      Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
+    }
+  },
+  methods: {
+    loadForm(obj) {
+      let { attributes, relationships } = obj;
+      this.form = {
         id: this.substance.id, // sid
         preferredName: attributes.preferredName,
         displayName: attributes.displayName,
@@ -153,15 +167,7 @@ export default {
         privateQcNote: attributes.privateQcNote,
         publicQcNote: attributes.publicQcNote
       };
-    }
-  },
-  watch: {
-    "substance.id": function() {
-      this.validationState = this.clearValidation();
-      Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
-    }
-  },
-  methods: {
+    },
     sumValues(obj) {
       return Object.values(obj).reduce((a, b) => a + b);
     },
@@ -172,24 +178,7 @@ export default {
       this.checkDataChanges(field);
     },
     resetForm() {
-      Object.keys(this.form).forEach(field => {
-        let initialValue;
-        let mapping;
-        if (field !== "id") {
-          if (this.dropdowns.includes(field)) {
-            initialValue = this.substance.relationships[field].data.id;
-            mapping = "relationships";
-          } else {
-            initialValue = this.substance.attributes[field] || "";
-            mapping = "attributes";
-          }
-          if (this.form[field] !== initialValue) {
-            let mix = { mapping, field, initialValue };
-            this.$store.commit("substance/resetDetail", mix);
-          }
-        }
-      });
-
+      this.loadForm(this.substance);
       this.validationState = this.clearValidation();
       Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
     },

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -52,8 +52,8 @@
       :disabled="btnDisabled"
       >Save Substance</b-button
     >
-    <b-button class="ml-2" @click="clearForm" variant="secondary"
-      >Clear Form</b-button
+    <b-button class="ml-2" @click="resetForm" variant="secondary"
+      >Reset Form</b-button
     >
   </b-form>
 </template>
@@ -121,7 +121,6 @@ export default {
         return false;
       }
     },
-
     btnDisabled: function() {
       if (this.compoundChanged) {
         return false;
@@ -172,10 +171,33 @@ export default {
     markChanged(field) {
       this.checkDataChanges(field);
     },
-    clearForm() {
-      this.$store.commit("substance/clearDetail");
-      this.validationState = this.clearValidation();
-      Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
+    resetForm() {
+
+      Object.keys(this.form).forEach(
+        field => {
+          let initialValue;
+          let mapping;
+          if (field !== "id"){
+            if (this.dropdowns.includes(field)) {
+              initialValue = this.substance.relationships[field].data.id;
+              mapping = "relationships";
+            } else {
+              initialValue = this.substance.attributes[field] || "";
+              mapping = "attributes";
+              };
+            
+            // if (this.form[field] !== initialValue) {
+              // console.log(this.form[field], ":b:", initialValue);
+              let mix = {mapping,field,initialValue};
+              this.$store.commit("substance/resetDetail", mix);
+            // }
+          }}
+      );
+     
+
+      
+      // this.validationState = this.clearValidation();
+      // Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
     },
     clearValidation() {
       let clean = {

--- a/src/components/substance/SubstanceForm.vue
+++ b/src/components/substance/SubstanceForm.vue
@@ -172,28 +172,24 @@ export default {
       this.checkDataChanges(field);
     },
     resetForm() {
+      Object.keys(this.form).forEach(field => {
+        let initialValue;
+        let mapping;
+        if (field !== "id") {
+          if (this.dropdowns.includes(field)) {
+            initialValue = this.substance.relationships[field].data.id;
+            mapping = "relationships";
+          } else {
+            initialValue = this.substance.attributes[field] || "";
+            mapping = "attributes";
+          }
+          if (this.form[field] !== initialValue) {
+            let mix = { mapping, field, initialValue };
+            this.$store.commit("substance/resetDetail", mix);
+          }
+        }
+      });
 
-      Object.keys(this.form).forEach(
-        field => {
-          let initialValue;
-          let mapping;
-          if (field !== "id"){
-            if (this.dropdowns.includes(field)) {
-              initialValue = this.substance.relationships[field].data.id;
-              mapping = "relationships";
-            } else {
-              initialValue = this.substance.attributes[field] || "";
-              mapping = "attributes";
-              };
-            if (this.form[field] !== initialValue) {
-              let mix = {mapping,field,initialValue};
-              this.$store.commit("substance/resetDetail", mix);
-            }
-          }}
-      );
-     
-
-      
       this.validationState = this.clearValidation();
       Object.keys(this.formChanged).forEach(v => (this.formChanged[v] = 0));
     },

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -137,8 +137,25 @@ const mutations = {
   loadDetail(state, payload) {
     state.detail = payload;
   },
-  clearDetail(state) {
-    state.detail = defaultDetail();
+  resetDetail(state, mix) {
+    console.log(mix);
+    // let pt1 = mix.mapping;
+    // let pt2 = mix.field;
+    let pt3 = mix.initialValue;
+    console.log(pt3)
+    if (mix.mapping === "attributes" ) {
+      state.detail.attributes[mix.field] = pt3;
+    }
+    
+    // console.log(state.detail);
+    // state.detail.attributes.displayName = "";
+
+    // Object.keys(state.detail).forEach(f => console.log(f))
+    // console.log(mix.mapping);
+
+
+
+
   },
   clearState(state) {
     Object.assign(state, defaultState());

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -138,24 +138,10 @@ const mutations = {
     state.detail = payload;
   },
   resetDetail(state, mix) {
-    console.log(mix);
-    // let pt1 = mix.mapping;
-    // let pt2 = mix.field;
-    let pt3 = mix.initialValue;
-    console.log(pt3)
     if (mix.mapping === "attributes" ) {
-      state.detail.attributes[mix.field] = pt3;
+      state.detail.attributes[mix.field] = mix.initialValue
     }
-    
-    // console.log(state.detail);
-    // state.detail.attributes.displayName = "";
-
-    // Object.keys(state.detail).forEach(f => console.log(f))
-    // console.log(mix.mapping);
-
-
-
-
+    else {state.detail.relationships[mix.field].data = {id: mix.initialValue, type: mix.field}}
   },
   clearState(state) {
     Object.assign(state, defaultState());

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -137,16 +137,6 @@ const mutations = {
   loadDetail(state, payload) {
     state.detail = payload;
   },
-  resetDetail(state, mix) {
-    if (mix.mapping === "attributes") {
-      state.detail.attributes[mix.field] = mix.initialValue;
-    } else {
-      state.detail.relationships[mix.field].data = {
-        id: mix.initialValue,
-        type: mix.field
-      };
-    }
-  },
   clearState(state) {
     Object.assign(state, defaultState());
   }

--- a/src/store/modules/substance.js
+++ b/src/store/modules/substance.js
@@ -138,10 +138,14 @@ const mutations = {
     state.detail = payload;
   },
   resetDetail(state, mix) {
-    if (mix.mapping === "attributes" ) {
-      state.detail.attributes[mix.field] = mix.initialValue
+    if (mix.mapping === "attributes") {
+      state.detail.attributes[mix.field] = mix.initialValue;
+    } else {
+      state.detail.relationships[mix.field].data = {
+        id: mix.initialValue,
+        type: mix.field
+      };
     }
-    else {state.detail.relationships[mix.field].data = {id: mix.initialValue, type: mix.field}}
   },
   clearState(state) {
     Object.assign(state, defaultState());

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -163,7 +163,6 @@ describe("The substance form", () => {
     );
   });
   it("should alert on unsaved Compounds", () => {
-    // quark
     cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
     cy.get("[data-cy=search-button]").click();
     cy.get("#compound-type-dropdown").select("Ill defined");
@@ -172,7 +171,6 @@ describe("The substance form", () => {
     );
   });
   it("should reset field changes on the Substance Form", () => {
-    // quark
     cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
     cy.get("[data-cy=search-button]").click();
     cy.get("#preferredName").type("Fake Name");

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -171,6 +171,14 @@ describe("The substance form", () => {
       "This Compound is not related to the Substance displayed."
     );
   });
+  it("should reset field changes", () => {
+    // quark
+    cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
+    cy.get("[data-cy=search-button]").click();
+    cy.get("#preferredName").type("Fake Name");
+    cy.get("#reset-substance-btn").click();
+    cy.get("#preferredName").contains("Hydrogen Peroxide");
+  });
 });
 
 describe("The substance page anonymous access", () => {

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -171,13 +171,14 @@ describe("The substance form", () => {
       "This Compound is not related to the Substance displayed."
     );
   });
-  it("should reset field changes", () => {
+  it("should reset field changes on the Substance Form", () => {
     // quark
     cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
     cy.get("[data-cy=search-button]").click();
     cy.get("#preferredName").type("Fake Name");
     cy.get("#reset-substance-btn").click();
-    cy.get("#preferredName").contains("Hydrogen Peroxide");
+    cy.get("#preferredName").should("have.value","Hydrogen Peroxide");
+    
   });
 });
 

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -705,6 +705,81 @@ describe("The substance page authenticated access", () => {
       .its("request.body.data.relationships.queryStructureType.data.id")
       .should("contain", "markush-query");
   });
+  it("should reset changes to the Ketcher window", () => {
+    // Get Substance w/ Defined Compound
+    cy.get("[data-cy=search-box]").type("Hydrogen Peroxide");
+    cy.get("[data-cy=search-button]").click();
+
+    // Modify H2O2 so the DTXCID changes
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(cy.wrap)
+      .find("#canvas")
+      .children()
+      .find("text")
+      .should("not.exist");
+
+    // Find the oxygen button
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(cy.wrap)
+      .find("#atom")
+      .find("button")
+      .eq(6)
+      .click();
+
+    // Select a point. add Oxygen
+    cy.get("iframe[id=ketcher]")
+      .its("0.contentDocument.body")
+      .should("not.be.empty")
+      .then(cy.wrap)
+      .find("#canvas")
+      .click();
+
+    // Changes have been made, Reset should not be disabled
+    cy.get("#reset-compound-btn").should("not.be.disabled");
+
+    // The DTXCID Field should change and show it is not associated
+    cy.get("#feedback-cid").contains(
+      "This Compound is not related to the Substance displayed."
+    );
+
+    // Reset Compound Editor Window
+    cy.get("#reset-compound-btn").click();
+
+    // The DTXCID for Hydrogen Peroxide should populate
+    cy.get("#recordCompoundID").should("have.value", "DTXCID502000024");
+  });
+
+  it("should reset changes to the Marvin window", () => {
+    // Get Substance w/ Illdefined Compound to modify
+    cy.get("[data-cy=search-box]").type("Sample Substance 2");
+    cy.get("[data-cy=search-button]").click();
+
+    // Click CycloHexane Button
+    cy.get("iframe[id=marvin]")
+      .its("0.contentDocument.body")
+      .find("[title=CycloHexane]")
+      .click();
+
+    // Add CycloHexane to the canvas
+    cy.get("iframe[id=marvin]")
+      .its("0.contentDocument.body")
+      .find("canvas#canvas")
+      .click();
+
+    // Reset button enabled
+    cy.get("#reset-compound-btn").should("not.be.disabled");
+
+    // Reset Compound
+    cy.get("#reset-compound-btn").click();
+
+    // The buttons should be disabled
+    cy.get("#reset-compound-btn").should("be.disabled");
+    cy.get("button:contains('Save Compound')").should("be.disabled");
+  });
 
   it("confirm navigation away from editor changes", () => {
     cy.get("iframe[id=marvin]")

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -177,8 +177,7 @@ describe("The substance form", () => {
     cy.get("[data-cy=search-button]").click();
     cy.get("#preferredName").type("Fake Name");
     cy.get("#reset-substance-btn").click();
-    cy.get("#preferredName").should("have.value","Hydrogen Peroxide");
-    
+    cy.get("#preferredName").should("have.value", "Hydrogen Peroxide");
   });
 });
 


### PR DESCRIPTION
Closes #148 

Adds ability to reset changes to the Substance Form and Chemical Editor Window.

- There are two buttons; one for the Substance Form and one for the Chemical Editor Window.
- Test for Substance Form reset
- Tests for Marvin & Ketcher window reset

**Substance**
![148-reset-substance](https://user-images.githubusercontent.com/74921039/106187278-6810d900-6173-11eb-982f-b8d411a0918b.png)
**Compound**
![148-reset-compound](https://user-images.githubusercontent.com/74921039/106187362-8aa2f200-6173-11eb-8e59-36d0b2caab9c.png)

