### PR TITLE
146 synonym crud alerts

### DIFF
--- a/src/components/ag-grid/agGridMixin.js
+++ b/src/components/ag-grid/agGridMixin.js
@@ -124,9 +124,9 @@ export const agGridMixin = {
      *       the state alert might be better than this approach
      */
     addAlert(message, style) {
-      this.alert.message = message
-      this.alert.style = style
-      this.alert.timer = this.maxTimer
+      this.alert.message = message;
+      this.alert.style = style;
+      this.alert.timer = this.maxTimer;
     },
 
     /**

--- a/src/components/ag-grid/agGridMixin.js
+++ b/src/components/ag-grid/agGridMixin.js
@@ -1,5 +1,4 @@
 import _ from "lodash";
-import { mapActions } from "vuex";
 import BtnCellRenderer from "@/components/ag-grid/BtnCellRenderer";
 import RelationshipTypeCellRenderer from "@/components/ag-grid/RelationshipTypeCellRenderer";
 import RelationshipTypeCellEditor from "@/components/ag-grid/RelationshipTypeCellEditor";
@@ -16,7 +15,13 @@ export const agGridMixin = {
       selectedRow: null,
       frameworkComponents: null,
       // Display options for error table.
-      errorFields: [{ label: "Errors", key: "modifiedDetail" }]
+      errorFields: [{ label: "Errors", key: "modifiedDetail" }],
+      alert: {
+        style: "success",
+        message: "",
+        timer: 0
+      },
+      maxTimer: 10
     };
   },
 
@@ -95,8 +100,6 @@ export const agGridMixin = {
   },
 
   methods: {
-    ...mapActions("alert", ["alert"]),
-
     /**
      * Rebuilds rowData with a provided array of jsonapi compliant synonyms
      *
@@ -111,17 +114,19 @@ export const agGridMixin = {
       return rowData;
     },
 
+    countDownChanged: function(countdown) {
+      this.alert.timer = countdown;
+    },
+
     /**
-     * Adds an alert to the page and scrolls the user to the top of the page
-     * so they can see it.
+     * Adds an alert to the an alert box
+     * todo: If the top of the page is visible,
+     *       the state alert might be better than this approach
      */
-    addAlert(message, color) {
-      this.alert({
-        message: message,
-        color: color,
-        dismissCountDown: 15
-      });
-      window.scrollTo(0, 0);
+    addAlert(message, style) {
+      this.alert.message = message
+      this.alert.style = style
+      this.alert.timer = this.maxTimer
     },
 
     /**

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -18,6 +18,7 @@
     />
     <b-alert
       class="mt-3"
+      id="synonym-alert"
       :variant="alert.style"
       :show="alert.timer"
       @dismiss-count-down="countDownChanged"
@@ -253,17 +254,17 @@ export default {
         row.initialData = { ...row.data };
         row.errors = null;
 
-        this.addAlert(`${row.data.identifier} was saved`, "success")
+        this.addAlert(`${row.data.identifier} was saved`, "success");
 
         return res;
-      }
+      };
 
       let onFailure = err => {
         row.errors = err.response.data.errors;
         return {
           failed: true
         };
-      }
+      };
 
       let requestBody = this.buildRequestBody(row.data);
 
@@ -287,7 +288,7 @@ export default {
         SynonymApi.delete(row.data.id)
           .then(() => {
             this.gridOptions.rowData.splice(row.rowIndex, 1);
-            this.addAlert(`${row.data.data.identifier} deleted`, "warning")
+            this.addAlert(`${row.data.data.identifier} deleted`, "warning");
           })
           .catch(err => {
             row.data.errors = err.response.data.errors;

--- a/src/components/synonyms/agSynonymTable.vue
+++ b/src/components/synonyms/agSynonymTable.vue
@@ -16,6 +16,13 @@
       @row-selected="onRowSelected"
       rowSelection="single"
     />
+    <b-alert
+      class="mt-3"
+      :variant="alert.style"
+      :show="alert.timer"
+      @dismiss-count-down="countDownChanged"
+      >{{ alert.message }}</b-alert
+    >
     <div v-show="selectedError" class="mt-3 text-left">
       <b-table
         id="synonym-error-table"
@@ -239,16 +246,19 @@ export default {
      */
     saveRequest: function(row) {
       // Local functions to deal with successful saves and failures
-      function onSuccess(res) {
+      let onSuccess = res => {
         // Save the id of the potentially newly minted row.
         row.id = res.data.data.id;
         row.created = false;
         row.initialData = { ...row.data };
         row.errors = null;
+
+        this.addAlert(`${row.data.identifier} was saved`, "success")
+
         return res;
       }
 
-      function onFailure(err) {
+      let onFailure = err => {
         row.errors = err.response.data.errors;
         return {
           failed: true
@@ -277,6 +287,7 @@ export default {
         SynonymApi.delete(row.data.id)
           .then(() => {
             this.gridOptions.rowData.splice(row.rowIndex, 1);
+            this.addAlert(`${row.data.data.identifier} deleted`, "warning")
           })
           .catch(err => {
             row.data.errors = err.response.data.errors;

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -1135,7 +1135,6 @@ describe("The substance page's Synonym Table", () => {
       .click();
 
     cy.get("#synonym-error-table").should("contain.text", sampleErrorMessage);
-    cy.get("#synonym-alert").should("not.be.visible");
   });
 });
 

--- a/tests/e2e/specs/substance.js
+++ b/tests/e2e/specs/substance.js
@@ -879,6 +879,8 @@ describe("The substance page's Synonym Table", () => {
       .should("be.enabled")
       .click();
 
+    cy.get("#synonym-alert").should("be.visible");
+
     cy.get("#synonym-table")
       .find("div.ag-center-cols-clipper")
       .find("div.ag-row[role=row]")
@@ -895,7 +897,61 @@ describe("The substance page's Synonym Table", () => {
       method: "POST",
       url: "/synonyms",
       status: 201,
-      response: {} // currently unneeded
+      response: {
+        data: {
+          id: "9",
+          type: "synonym",
+          attributes: {
+            identifiers: "Synonym 9",
+            qcNotes: ""
+          },
+          relationships: {
+            source: {
+              links: {
+                self: "http://localhost:8000/synonyms/3/relationships/source",
+                related: "http://localhost:8000/synonyms/3/source"
+              },
+              data: {
+                type: "source",
+                id: "7"
+              }
+            },
+            substance: {
+              links: {
+                self:
+                  "http://localhost:8000/synonyms/3/relationships/substance",
+                related: "http://localhost:8000/synonyms/3/substance"
+              },
+              data: {
+                type: "substance",
+                id: "2"
+              }
+            },
+            synonymQuality: {
+              links: {
+                self:
+                  "http://localhost:8000/synonyms/3/relationships/synonymQuality",
+                related: "http://localhost:8000/synonyms/3/synonymQuality"
+              },
+              data: {
+                type: "synonymQuality",
+                id: "8"
+              }
+            },
+            synonymType: {
+              links: {
+                self:
+                  "http://localhost:8000/synonyms/3/relationships/synonymType",
+                related: "http://localhost:8000/synonyms/3/synonymType"
+              },
+              data: {
+                type: "synonymType",
+                id: "5"
+              }
+            }
+          }
+        }
+      }
     }).as("post");
 
     cy.get("[data-cy=search-box]").type("Sample Substance 2");
@@ -953,6 +1009,8 @@ describe("The substance page's Synonym Table", () => {
       .eq(5)
       .find("button")
       .click();
+
+    cy.get("#synonym-alert").should("be.visible");
 
     cy.get("@post")
       .its("request.body.data")
@@ -1077,6 +1135,7 @@ describe("The substance page's Synonym Table", () => {
       .click();
 
     cy.get("#synonym-error-table").should("contain.text", sampleErrorMessage);
+    cy.get("#synonym-alert").should("not.be.visible");
   });
 });
 


### PR DESCRIPTION
closes #146 

Adds an incredibly simple alert to deletes and saves below the synonym table.  This doesn't look great but without this being a finalized version of the page it at least gets the job done.  It also doesn't move the table which should help editing multiple rows.